### PR TITLE
Provide ability to set field to a unique string by default.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,3 +33,4 @@ Lucas Morales <lmorales@edx.org>
 Eugeny Kolpakov <eugeny.kolpakov@gmail.com>
 David Bodor <david.gabor.bodor@gmail.com>
 Dhruv Baldawa <dhruvbaldawa@gmail.com>
+Matjaz Gregoric <mtyaka@gmail.com>

--- a/doc/guide/xblock.rst
+++ b/doc/guide/xblock.rst
@@ -174,6 +174,8 @@ If you would like to use ``init`` function for some reason, such as to implement
 more complicated logic for default field values, consider one of the following
 alternatives:
 
+- Use ``xblock.fields.UNIQUE_ID`` if you want the field to default to a unique
+  string value.
 - Use a lazy property decorator, so that when you first access an attribute, a
   function will be called to set that attribute.
 - Call the default-field-value logic in the view, instead of in ``init``.

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -28,7 +28,7 @@ import copy
 from mock import Mock
 
 from xblock.core import XBlock
-from xblock.fields import Integer, List, ScopeIds
+from xblock.fields import Integer, List, String, ScopeIds, UNIQUE_ID
 from xblock.field_data import DictFieldData
 
 from xblock.test.tools import (
@@ -400,6 +400,13 @@ class MutableTestCases(UniversalTestCases, MutationProperties):
     def mutate(self, value):
         """Modify the supplied value"""
         value.append('foo')
+
+
+class UniqueIdTestCases(ImmutableTestCases):
+    """Set up tests for field with UNIQUE_ID default"""
+    field_class = String
+    field_default = UNIQUE_ID
+    new_value = 'user-assigned ID'
 # pylint: enable=no-member
 
 
@@ -408,9 +415,8 @@ class TestImmutableWithStaticDefault(ImmutableTestCases, StaticDefaultTestCases)
     __test__ = False
 
 
-class TestImmutableWithInitialValue(ImmutableTestCases, InitialValueProperties):
+class TestImmutableWithUniqueIdDefault(UniqueIdTestCases, StaticDefaultTestCases):
     __test__ = False
-    initial_value = 75
 
 
 class TestImmutableWithComputedDefault(ImmutableTestCases, ComputedDefaultTestCases):
@@ -436,6 +442,16 @@ class TestMutableWithComputedDefault(MutableTestCases, ComputedDefaultTestCases,
     @property
     def default_iterator(self):
         return ([None] * i for i in xrange(1000))
+
+
+class TestImmutableWithInitialValue(ImmutableTestCases, InitialValueProperties):
+    __test__ = False
+    initial_value = 75
+
+
+class TestImmutableWithInitialValueAndUniqueIdDefault(UniqueIdTestCases, InitialValueProperties):
+    __test__ = False
+    initial_value = 'initial unique ID'
 
 
 # ~~~~~~~~~~~~~ Classes for testing noops before other tests ~~~~~~~~~~~~~~~~~~~~
@@ -490,7 +506,8 @@ for operation_backend in (BlockFirstOperations, FieldFirstOperations):
     for noop_prefix in (None, GetNoopPrefix, GetSaveNoopPrefix, SaveNoopPrefix):
         for base_test_case in (
                 TestImmutableWithComputedDefault, TestImmutableWithInitialValue, TestImmutableWithStaticDefault,
-                TestMutableWithComputedDefault, TestMutableWithInitialValue, TestMutableWithStaticDefault
+                TestMutableWithComputedDefault, TestMutableWithInitialValue, TestMutableWithStaticDefault,
+                TestImmutableWithUniqueIdDefault, TestImmutableWithInitialValueAndUniqueIdDefault
         ):
 
             test_name = base_test_case.__name__ + "With" + operation_backend.__name__


### PR DESCRIPTION
Provide ability to set field to a unique string by default.

This patch makes it possible to set a field's default value to a unique string that appears random, but is deterministically calculated for a field in the given scope:

    my_field = xblock.fields.String(default=xblock.fields.UNIQUE_ID, ...)

It provides an alternative approach to callable defaults as discussed at https://github.com/edx/XBlock/pull/247. It was also discussed in https://groups.google.com/forum/#!topic/edx-code/eRZtQ7t4JJY.

- Partner information: 3rd party-hosted open edX instance, for an edX solutions client (so will need to get some sort of solution merged in)
- Merge deadline: 30th November (soft requirement to minimize code drift, we maintain it on the client fork in the meantime)
