### PR TITLE
You can disable silent failures

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -116,11 +116,22 @@ class XBlock(XmlSerializationMixin, HierarchyMixin, ScopedStorageMixin, RuntimeS
         return dec
 
     @classmethod
-    def load_tagged_classes(cls, tag):
-        """Produce a sequence of all XBlock classes tagged with `tag`."""
+    def load_tagged_classes(cls, tag, fail_silently=True):
+        """
+        Produce a sequence of all XBlock classes tagged with `tag`.
+
+        fail_silently causes the code to simply log warnings if a
+        plugin cannot import. The goal is to be able to use part of
+        libraries from an XBlock (and thus have it installed), even if
+        the overall XBlock cannot be used (e.g. depends on Django in a
+        non-Django application). There is diagreement about whether
+        this is a good idea, or whether we should see failures early
+        (e.g. on startup or first page load), and in what
+        contexts. Hence, the flag.
+        """
         # Allow this method to access the `_class_tags`
         # pylint: disable=W0212
-        for name, class_ in cls.load_classes():
+        for name, class_ in cls.load_classes(fail_silently):
             if tag in class_._class_tags:
                 yield name, class_
 

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -120,12 +120,20 @@ class Plugin(object):
         return PLUGIN_CACHE[key]
 
     @classmethod
-    def load_classes(cls):
+    def load_classes(cls, fail_silently=True):
         """Load all the classes for a plugin.
 
         Produces a sequence containing the identifiers and their corresponding
         classes for all of the available instances of this plugin.
 
+        fail_silently causes the code to simply log warnings if a
+        plugin cannot import. The goal is to be able to use part of
+        libraries from an XBlock (and thus have it installed), even if
+        the overall XBlock cannot be used (e.g. depends on Django in a
+        non-Django application). There is diagreement about whether
+        this is a good idea, or whether we should see failures early
+        (e.g. on startup or first page load), and in what
+        contexts. Hence, the flag.
         """
         all_classes = itertools.chain(
             pkg_resources.iter_entry_points(cls.entry_point),
@@ -135,7 +143,10 @@ class Plugin(object):
             try:
                 yield (class_.name, cls._load_class_entry_point(class_))
             except Exception:  # pylint: disable=broad-except
-                log.warning('Unable to load %s %r', cls.__name__, class_.name, exc_info=True)
+                if fail_silently:
+                    log.warning('Unable to load %s %r', cls.__name__, class_.name, exc_info=True)
+                else:
+                    raise
 
     @classmethod
     def register_temp_plugin(cls, class_, identifier=None, dist='xblock'):


### PR DESCRIPTION
Right now, if an XBlock is broken, you get a silent failure, with no way to debug, no way to know. Things just randomly don't show up or work. 

This PR gives the option to disable that. I'll make a mating PR to xblock-sdk.