### PR TITLE
index_view exposable in XBlocks

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -19,7 +19,8 @@ from xblock.mixins import (
     HierarchyMixin,
     RuntimeServicesMixin,
     HandlersMixin,
-    XmlSerializationMixin
+    XmlSerializationMixin,
+    IndexInfoMixin
 )
 from xblock.plugin import Plugin
 from xblock.validation import Validation
@@ -79,7 +80,7 @@ class SharedBlockBase(Plugin):
 
 # -- Base Block
 class XBlock(XmlSerializationMixin, HierarchyMixin, ScopedStorageMixin, RuntimeServicesMixin, HandlersMixin,
-             SharedBlockBase):
+             IndexInfoMixin, SharedBlockBase):
     """Base class for XBlocks.
 
     Derive from this class to create a new kind of XBlock.  There are no

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -458,3 +458,18 @@ class XmlSerializationMixin(ScopedStorageMixin):
             node.insert(0, elem)
         else:
             node.set(field_name, unicode(field.read_from(self)))
+
+
+class IndexInfoMixin(object):
+    """
+    This mixin provides interface for classes that wish to provide index
+    information which might be used within a search index
+    """
+
+    def index_dictionary(self):
+        """
+        return key/value fields to feed an index within in a Python dict object
+        values may be numeric / string or dict
+        default implementation is an empty dict
+        """
+        return {}

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -912,3 +912,43 @@ class TestXBlockDeprecation(WarningTestMixin, unittest.TestCase):
         with self.assertWarns(FieldDataDeprecationWarning):
             block._field_data = field_data
         self.assertEqual(field_data, block._field_data)
+
+
+class TestIndexResults(unittest.TestCase):
+    """
+    Tests to confirm that default block has empty index, and that XBlocks can provide custom index dictionary
+    """
+
+    class TestXBlock(XBlock):
+        """
+        Class to test default Xblock provides a dictionary
+        """
+        pass
+
+    class TestIndexedXBlock(XBlock):
+        """
+        Class to test when an Xblock provides a dictionary
+        """
+
+        def index_dictionary(self):
+            return {
+                "test_field": "ABC123",
+                "text_block": "Here is some text that was indexed",
+            }
+
+    def test_default_index_view(self):
+        test_runtime = TestRuntime(services={'field-data': DictFieldData({})})
+        test_xblock = self.TestXBlock(test_runtime, scope_ids=Mock(spec=ScopeIds))
+
+        index_info = test_xblock.index_dictionary()
+        self.assertFalse(index_info)
+        self.assertTrue(isinstance(index_info, dict))
+
+    def test_override_index_view(self):
+        test_runtime = TestRuntime(services={'field-data': DictFieldData({})})
+        test_xblock = self.TestIndexedXBlock(test_runtime, scope_ids=Mock(spec=ScopeIds))
+
+        index_info = test_xblock.index_dictionary()
+        self.assertTrue(index_info)
+        self.assertTrue(isinstance(index_info, dict))
+        self.assertEqual(index_info["test_field"], "ABC123")

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -5,7 +5,7 @@ Tests of the XBlock-family functionality mixins
 from unittest import TestCase
 
 from xblock.fields import List, Scope, Integer
-from xblock.mixins import ScopedStorageMixin, HierarchyMixin
+from xblock.mixins import ScopedStorageMixin, HierarchyMixin, IndexInfoMixin
 
 
 class AttrAssertionMixin(TestCase):
@@ -118,3 +118,18 @@ class TestHierarchyMixin(AttrAssertionMixin, TestCase):
         self.assertEqual(Scope.children, self.HasChildren.children.scope)
         self.assertIsInstance(self.InheritedChildren.children, List)
         self.assertEqual(Scope.children, self.InheritedChildren.children.scope)
+
+
+class TestIndexInfoMixin(AttrAssertionMixin):
+    """
+    Tests for Index
+    """
+    class IndexInfoMixinTester(IndexInfoMixin):
+        """Test class for index mixin"""
+        pass
+
+    def test_index_info(self):
+        self.assertHasAttr(self.IndexInfoMixinTester, 'index_dictionary')
+        with_index_info = self.IndexInfoMixinTester().index_dictionary()
+        self.assertFalse(with_index_info)
+        self.assertTrue(isinstance(with_index_info, dict))


### PR DESCRIPTION
@cdodge, @chrisndodge & maybe @mattdrayer  - Please review and then I'll open up to a wider. This is the base implementation of the IndexInfoMixin to be used for XBlocks to override when providing index information.