### PR TITLE
Ignore comments when parsing XML

### DIFF
--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -374,6 +374,8 @@ class XmlSerializationMixin(ScopedStorageMixin):
         # The base implementation: child nodes become child blocks.
         # Or fields, if they belong to the right namespace.
         for child in node:
+            if child.tag is etree.Comment:
+                continue
             qname = etree.QName(child)
             tag = qname.localname
             namespace = qname.namespace

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -682,8 +682,7 @@ class Runtime(object):
 
     def parse_xml_file(self, fileobj, id_generator=None):
         """Parse an open XML file, returning a usage id."""
-        parser = etree.XMLParser(remove_comments=True)
-        root = etree.parse(fileobj, parser=parser).getroot()
+        root = etree.parse(fileobj).getroot()
         usage_id = self._usage_id_from_node(root, None, id_generator)
         return usage_id
 

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -682,7 +682,8 @@ class Runtime(object):
 
     def parse_xml_file(self, fileobj, id_generator=None):
         """Parse an open XML file, returning a usage id."""
-        root = etree.parse(fileobj).getroot()
+        parser = etree.XMLParser(remove_comments=True)
+        root = etree.parse(fileobj, parser=parser).getroot()
         usage_id = self._usage_id_from_node(root, None, id_generator)
         return usage_id
 

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -132,6 +132,20 @@ class ParsingTest(XmlTest, unittest.TestCase):
         self.assertEqual(child2.parent, block.scope_ids.usage_id)
 
     @XBlock.register_temp_plugin(Leaf)
+    @XBlock.register_temp_plugin(Container)
+    def test_xml_with_comments(self):
+        block = self.parse_xml_to_block("""\
+                    <!-- This is a comment -->
+                    <container>
+                        <leaf data1='child1'/>
+                        <!-- <leaf data1='ignore'/> -->
+                        <leaf data1='child2'/>
+                    </container>
+                    """)
+        self.assertIsInstance(block, Container)
+        self.assertEqual(len(block.children), 2)
+
+    @XBlock.register_temp_plugin(Leaf)
     @XBlock.register_temp_plugin(Specialized)
     def test_customized_parsing(self):
         block = self.parse_xml_to_block("""\

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -7,6 +7,7 @@ import textwrap
 import unittest
 import ddt
 import mock
+from lxml import etree
 
 from xblock.core import XBlock, XML_NAMESPACES
 from xblock.fields import Scope, String, Integer, Dict, List
@@ -59,6 +60,33 @@ class Specialized(XBlock):
         block = runtime.construct_xblock_from_class(cls, keys)
         block.num_children = len(node)
         return block
+
+
+class CustomXml(XBlock):
+    """A block that does its own XML parsing and preserves comments"""
+    inner_xml = String(default='', scope=Scope.content)
+    has_children = True
+
+    @classmethod
+    def parse_xml(cls, node, runtime, keys, id_generator):
+        """Parse the XML node and save it as a string"""
+        block = runtime.construct_xblock_from_class(cls, keys)
+        for child in node:
+            if child.tag is not etree.Comment:
+                block.runtime.add_node_as_child(block, child, id_generator)
+        # Now build self.inner_xml from the XML of node's children
+        # We can't just call tostring() on each child because it adds xmlns: attributes
+        xml_str = etree.tostring(node)
+        block.inner_xml = xml_str[xml_str.index('>') + 1:xml_str.rindex('<')]
+        return block
+
+    def add_xml_to_node(self, node):
+        """ For exporting, set data on `node` from ourselves. """
+        node.tag = self.xml_element_name()
+        parsed_inner_xml = etree.XML('<x>{}</x>'.format(self.inner_xml))
+        node.text = parsed_inner_xml.text
+        for child in parsed_inner_xml:
+            node.append(child)
 
 # Helpers
 
@@ -144,6 +172,27 @@ class ParsingTest(XmlTest, unittest.TestCase):
                     """)
         self.assertIsInstance(block, Container)
         self.assertEqual(len(block.children), 2)
+
+    @XBlock.register_temp_plugin(Leaf)
+    @XBlock.register_temp_plugin(CustomXml)
+    def test_comments_in_field_preserved(self):
+        """
+        Check that comments made by users inside field data are preserved.
+        """
+        block = self.parse_xml_to_block("""\
+                    <!-- This is a comment outside a block - it can be lost -->
+                    <customxml>A<!--B--><leaf/>C<leaf/><!--D-->E</customxml>
+                    """)
+        self.assertIsInstance(block, CustomXml)
+        self.assertEqual(len(block.children), 2)
+
+        xml = self.export_xml_for_block(block)
+        self.assertIn('A<!--B--><leaf/>C<leaf/><!--D-->E', xml)
+        block_imported = self.parse_xml_to_block(xml)
+        self.assertEqual(
+            block_imported.inner_xml,
+            "A<!--B--><leaf/>C<leaf/><!--D-->E"
+        )
 
     @XBlock.register_temp_plugin(Leaf)
     @XBlock.register_temp_plugin(Specialized)


### PR DESCRIPTION
**Description**: This is a simple change to ignore comments when parsing XML *using the default parser built into XBlock*. Currently, if the XML includes comments, an error will result and the XBlock tree construction fails. For example, right now in general you cannot put comments into xblock-sdk workbench scenarios.

**Use cases**:
* Adding explanatory comments to course exports or workbench scenarios
* Temporarily disabling blocks in XML by commenting them out
* Some XBlocks currently have an "editor" interface that's just a big XML field where users can edit the XML that defines them and their child blocks. We currently have to override the `parse_xml` method in each such block to add code to ignore comments in order to avoid errors when users add them as part of an edit.

**Affects**:
* Any XBlock that uses the default XML parser to load itself and/or its children from an XML representation. (e.g. during course import and export, in the XBlock SDK workbench)

**Does not affect**:
* Any XBlocks that implement their own `parse_xml` method
* Blocks that store XML as a string in one of their fields.
* CAPA problem XML - capa XML is stored as a string in the "data" field, has its own parser, and is not built of XBlock XML but rather a separate XML language specific to capa.

**What about serialization**? This ignores the comments, so if you create an XBlock from XML, then ask that XBlock to export itself as XML [using the default serialization code](https://github.com/edx/XBlock/blob/master/xblock/mixins.py#L400), the XML is re-created from scratch and the comments will be gone. Note that this does not break any existing behaviour as comments are not currently allowed unless specifically implemented by a particular XBlock. As well, this does not affect capa problems or blocks that store XML in fields other than "content" or that do their own XML parsing/export.

However, XBlocks that use XML to define their configuration/children and that wish to preserve comments can do so using a custom XML parser, as shown in one of the new test cases.
