### PR TITLE
Clarify Apache 2.0 license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,8 +163,8 @@ the XBlock SDK: https://github.com/edx/xblock-sdk
 License
 -------
 
-The code in this repository is licensed under version 3 of the AGPL unless
-otherwise noted.
+The code in this repository is licensed the Apache 2.0 license unless otherwise
+noted.
 
 Please see ``LICENSE.txt`` for details.
 

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,9 @@ setup(
         'python-dateutil',
         'pytz',
         'webob',
-    ]
+    ],
+    license='Apache 2.0',
+    classifiers=(
+        "License :: OSI Approved :: Apache Software License 2.0",
+    )
 )


### PR DESCRIPTION
The code in this repository used to be licensed under the AGPL license, but it was switched to the Apache 2.0 license in #231. Looks like we missed a few references, though. @nedbat, can you review this?