### PR TITLE
Fixed exporting List and Dict with unicode contents

### DIFF
--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -453,13 +453,14 @@ class XmlSerializationMixin(ScopedStorageMixin):
         Depending on settings, it either stores the value of field
         as an xml attribute or creates a separate child node.
         """
+        value = field.to_string(field.read_from(self))
         if field.xml_node:
             tag = etree.QName(XML_NAMESPACES["option"], field_name)
             elem = node.makeelement(tag)
-            elem.text = field.to_string(field.read_from(self))
+            elem.text = value
             node.insert(0, elem)
         else:
-            node.set(field_name, unicode(field.read_from(self)))
+            node.set(field_name, value)
 
 
 class IndexInfoMixin(object):


### PR DESCRIPTION
**Description:** This PR fixes the issue with importing-exporting XBlocks, containing List and Dict XBLock fields.
**Background:** Previously, xml export code relied on the fact that python list and dict string representation matches json array and dictionary notation. This is true unless unicode items, keys or values are present - in such a case they are serialized as `u'label'` instead of `'label'`, and subsequent import fails.
**JIRA Tickets:** [SOL-574](https://openedx.atlassian.net/browse/SOL-574), [SOL-575](https://openedx.atlassian.net/browse/SOL-575), [OSPR-496](https://openedx.atlassian.net/browse/OSPR-496)
**Related:** edx-solutions fork get's [dedicated fix](https://github.com/edx-solutions/XBlock/commit/54eb39cf8eb45c2adeb412cc784e989d8e3693e8) as part of birch migration. 
**Testing instructions:** 
1. *before* merging this PR, create a course with an XBlock that uses List or Dict field to store some of it's configuration (e.g. [xblock-drag-and-drop-v2](https://github.com/edx-solutions/xblock-drag-and-drop-v2))
2. Export the course.
3. Import as *another course*. Import should succeed.
4. Open unit containing exported XBlock either in Studio or LMS
5. Exception should be raised, XBlock is not rendered.
6. *Merge* the fix
7. Reexport source course.
8. Import as another course (could reuse course from strep 3). Import should succeed.
9. Open unit containing exported XBlock either in Studio or LMS
10. Xblock should render just fine