### PR TITLE
EXPLICITLY_SET always overrides _dirty_fields content

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -405,7 +405,7 @@ class Field(Nameable):
 
         # Deep copy the value being marked as dirty, so that there
         # is a baseline to check against when saving later
-        if self not in xblock._dirty_fields:
+        if self not in xblock._dirty_fields or value is EXPLICITLY_SET:
             xblock._dirty_fields[self] = copy.deepcopy(value)
 
     def _is_dirty(self, xblock):

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -26,7 +26,9 @@ from xblock.fields import (
     UNIQUE_ID
 )
 
-from xblock.test.tools import assert_equals, assert_not_equals, assert_not_in, TestRuntime
+from xblock.test.tools import (
+    assert_equals, assert_not_equals, assert_in, assert_not_in, assert_false, assert_true, TestRuntime
+)
 from xblock.fields import scope_key, ScopeIds
 
 
@@ -542,6 +544,39 @@ def test_twofaced_field_access():
     assert_equals(len(field_tester._dirty_fields), 1)
     # However, the field should not ACTUALLY be marked as a field that is needing to be saved.
     assert_not_in('how_many', field_tester._get_fields_to_save())   # pylint: disable=W0212
+
+
+def test_setting_the_same_value_marks_field_as_dirty():
+    """
+    Check that setting field to the same value does not mark mutable fields as dirty.
+    This might be an unexpected behavior though
+    """
+    class FieldTester(XBlock):
+        """Test block for set - get test."""
+        non_mutable = String(scope=Scope.settings)
+        list_field = List(scope=Scope.settings)
+        dict_field = Dict(scope=Scope.settings)
+
+    runtime = TestRuntime(services={'field-data': DictFieldData({})})
+    field_tester = FieldTester(runtime, scope_ids=Mock(spec=ScopeIds))
+
+    # precondition checks
+    assert_equals(len(field_tester._dirty_fields), 0)
+    assert_false(field_tester.fields['list_field'].is_set_on(field_tester))
+    assert_false(field_tester.fields['dict_field'].is_set_on(field_tester))
+    assert_false(field_tester.fields['non_mutable'].is_set_on(field_tester))
+
+    field_tester.non_mutable = field_tester.non_mutable
+    field_tester.list_field = field_tester.list_field
+    field_tester.dict_field = field_tester.dict_field
+
+    assert_in(field_tester.fields['non_mutable'], field_tester._dirty_fields)
+    assert_in(field_tester.fields['list_field'], field_tester._dirty_fields)
+    assert_in(field_tester.fields['dict_field'], field_tester._dirty_fields)
+
+    assert_true(field_tester.fields['non_mutable'].is_set_on(field_tester))
+    assert_true(field_tester.fields['list_field'].is_set_on(field_tester))
+    assert_true(field_tester.fields['dict_field'].is_set_on(field_tester))
 
 
 class SentinelTest(unittest.TestCase):

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -25,7 +25,7 @@ particular combination of initial conditions that we want to test)
 """
 
 import copy
-from mock import Mock
+from mock import Mock, patch
 
 from xblock.core import XBlock
 from xblock.fields import Integer, List, String, ScopeIds, UNIQUE_ID
@@ -162,6 +162,13 @@ class UniversalProperties(object):
         self.block.save()
         assert_false(self.field_data.has(self.block, 'field'))
         assert_true(self.is_default())
+
+    def test_set_after_get_always_saves(self):
+        with patch.object(self.field_data, 'set_many') as patched_set_many:
+            self.set(self.get())
+            self.block.save()
+
+            patched_set_many.assert_called_with(self.block, {'field': self.get()})
 
 
 class MutationProperties(object):


### PR DESCRIPTION
**Background and Motivation:** edx-platform import routine includes updating xblock location and explicitly [setting some fields to their values](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/xml_importer.py#L1160-1171) in order to mark them as dirty (note the comment). However, this found to be wrong, as MUTABLE fields (e.g. `List` and `Dict`) are marked as dirty [*on read*](https://github.com/edx/XBlock/blob/master/xblock/fields.py#L490-491). As a result, setting mutable field to the same value does not mark it as dirty, as ["baseline"](https://github.com/edx/XBlock/blob/master/xblock/fields.py#L419) was just set to the same value. This, in turn, breaks importing later, but only for drafts, as published versions does not pass through `_update_module_location` method that updates the location to draft. As a result, mutable fields e.g. `children`) are not saved with block.

So the issue was traced down to [`_mark_dirty`](https://github.com/edx/XBlock/blob/master/xblock/fields.py#L408) function - it looks like, despite being explicitly set when parsing xml, neither `children`, nor `correct_choices` (both of type `List`) were not marked as dirty. Hence the proposed fix - always mark fields as dirty if explicitly assigned.

Also, particular feature of this bug is that it affects only draft versions - published work just fine. Side effect - LMS shows correct data.

**JIRA Ticket**: [SOL-810](https://openedx.atlassian.net/browse/SOL-810)
**Related:** [OSPR-517](https://openedx.atlassian.net/browse/OSPR-517), [PR 299(closed)](https://github.com/edx/XBlock/pull/299) - contains discussion about why this PR was reactivated; [SOL-811](https://openedx.atlassian.net/browse/SOL-811)
**Sandbox**: [LMS](http://sandbox3.opencraft.com/), [Studio](http://sandbox3.opencraft.com:18010/)
**Partner information:** 3rd party-hosted open edX instance, for an edX solutions client.
**Merge dealine:** preferably Friday, May 1st (in time for next release).
**Scope:** Probably any kinds of XBlocks that have children and `Scope.settings` fields simultaneously. Might not be the case for non-split modulestores.
**Test Instructions:** No user-facing changes, use test instructions for [edx-platform import fix PR](https://github.com/edx/edx-platform/pull/7816)