### PR TITLE
Declaring `allow_duplicate = True` in the keyword argument in field defi...

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -308,7 +308,7 @@ class Field(Nameable):
     # We're OK redefining built-in `help`
     def __init__(self, help=None, default=UNSET, scope=Scope.content,  # pylint:disable=redefined-builtin
                  display_name=None, values=None, enforce_type=False,
-                 xml_node=False, **kwargs):
+                 xml_node=False, allow_duplicate=True, **kwargs):
         self.warned = False
         self.help = help
         self._enable_enforce_type = enforce_type
@@ -322,6 +322,7 @@ class Field(Nameable):
         self._values = values
         self.runtime_options = kwargs
         self.xml_node = xml_node
+        self.allow_duplicate = allow_duplicate
 
     @property
     def default(self):


### PR DESCRIPTION
Added a keyword argument `allow_duplicate` in the field definition which will identify which fields can be  duplicated.


[TNL-1754] (https://openedx.atlassian.net/browse/TNL-1754)