### PR TITLE
force_dirty method for fields

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -399,13 +399,13 @@ class Field(Nameable):
         if hasattr(xblock, '_field_data_cache') and self.name in xblock._field_data_cache:
             del xblock._field_data_cache[self.name]
 
-    def _mark_dirty(self, xblock, value):
+    def _mark_dirty(self, xblock, value, force=False):
         """Set this field to dirty on the xblock."""
         # pylint: disable=protected-access
 
         # Deep copy the value being marked as dirty, so that there
         # is a baseline to check against when saving later
-        if self not in xblock._dirty_fields:
+        if self not in xblock._dirty_fields or force:
             xblock._dirty_fields[self] = copy.deepcopy(value)
 
     def _is_dirty(self, xblock):
@@ -632,6 +632,11 @@ class Field(Nameable):
         """
         # pylint: disable=protected-access
         return self._is_dirty(xblock) or xblock._field_data.has(xblock, self.name)
+
+    def force_dirty(self, xblock):
+        """ Force set dirty status on field """
+        self._mark_dirty(xblock, EXPLICITLY_SET, force=True)
+        self._set_cached_value(xblock, getattr(xblock, self.name))
 
     def __hash__(self):
         return hash(self.name)

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -26,7 +26,7 @@ from xblock.fields import (
     UNIQUE_ID
 )
 
-from xblock.test.tools import assert_equals, assert_not_equals, assert_not_in, TestRuntime
+from xblock.test.tools import assert_equals, assert_not_equals, assert_in, assert_not_in, TestRuntime
 from xblock.fields import scope_key, ScopeIds
 
 
@@ -542,6 +542,29 @@ def test_twofaced_field_access():
     assert_equals(len(field_tester._dirty_fields), 1)
     # However, the field should not ACTUALLY be marked as a field that is needing to be saved.
     assert_not_in('how_many', field_tester._get_fields_to_save())   # pylint: disable=W0212
+
+
+def test_force_dirty():
+    """
+    Check that force dirty marks field as dirty even if field was not updated
+    """
+    class FieldTester(XBlock):
+        """Test block for TwoFacedField."""
+        list_field = List(scope=Scope.settings)
+
+    runtime = TestRuntime(services={'field-data': DictFieldData({'list_field': []})})
+    field_tester = FieldTester(runtime, scope_ids=Mock(spec=ScopeIds))
+
+    # precondition checks
+    assert_equals(len(field_tester._dirty_fields), 0)
+
+    field_tester.fields['list_field'].force_dirty(field_tester)
+
+    # This should mark it as dirty
+    assert_equals(len(field_tester._dirty_fields), 1)
+
+    # And the field should BE marked as a field that is needing to be saved.
+    assert_in('list_field', field_tester._get_fields_to_save())   # pylint: disable=W0212
 
 
 class SentinelTest(unittest.TestCase):


### PR DESCRIPTION
**Motivation:** edx-platform import routine includes updating xblock location and explicitly [setting some fields to their values](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/xml_importer.py#L1160-1171) in order to mark them as dirty (note the comment). However, this found to be wrong, as MUTABLE fields (e.g. `List` and `Dict`) are marked as dirty [*on read*](https://github.com/edx/XBlock/blob/master/xblock/fields.py#L490-491). As a result, setting mutable field to the same value does not mark it as dirty, as ["baseline"](https://github.com/edx/XBlock/blob/master/xblock/fields.py#L419) was just set to the same value. This, in turn, breaks importing later, but only for drafts, as published versions does not pass through `_update_module_location` method that updates the location to draft.
**JIRA Ticket**: [SOL-810](https://openedx.atlassian.net/browse/SOL-810)
**Related:** [OSPR-517](https://openedx.atlassian.net/browse/OSPR-517), [PR 295(closed)](https://github.com/edx/XBlock/pull/295) - contains detailed problem explanation.
**Sandbox**: [LMS](http://sandbox3.opencraft.com/), [Studio](http://sandbox3.opencraft.com:18010/)
**Test Instructions:** No user-facing changes, use test instructions for [edx-platform import fix PR](https://github.com/edx/edx-platform/pull/7816)
**Partner information:** 3rd party-hosted open edX instance, for an edX solutions client.
**Merge dealine:** preferably Friday, May 1st (in time for next release).