### PR TITLE
Adam/add force save fields 2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,4 @@ Eugeny Kolpakov <eugeny.kolpakov@gmail.com>
 David Bodor <david.gabor.bodor@gmail.com>
 Dhruv Baldawa <dhruvbaldawa@gmail.com>
 Matjaz Gregoric <mtyaka@gmail.com>
+Adam Palay <adam@edx.org>

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -498,11 +498,22 @@ class Field(Nameable):
         Setting a value does not update the underlying data store; the
         new value is kept in the cache and the xblock is marked as
         dirty until `save` is explicitly called.
+
+        Note, if there's already a cached value and it's equal to the value
+        we're trying to cache, we won't do anything.
         """
         value = self._check_or_enforce_type(value)
-        # Mark the field as dirty and update the cache:
-        self._mark_dirty(xblock, EXPLICITLY_SET)
-        self._set_cached_value(xblock, value)
+        cached_value = self._get_cached_value(xblock)
+        try:
+            value_has_changed = cached_value != value
+        except Exception:  # pylint: disable=broad-except
+            # if we can't compare the values for whatever reason
+            # (i.e. timezone aware and unaware datetimes), just reset the value.
+            value_has_changed = True
+        if value_has_changed:
+            # Mark the field as dirty and update the cache
+            self._mark_dirty(xblock, EXPLICITLY_SET)
+            self._set_cached_value(xblock, value)
 
     def __delete__(self, xblock):
         """

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -405,7 +405,7 @@ class Field(Nameable):
 
         # Deep copy the value being marked as dirty, so that there
         # is a baseline to check against when saving later
-        if self not in xblock._dirty_fields or value is EXPLICITLY_SET:
+        if self not in xblock._dirty_fields:
             xblock._dirty_fields[self] = copy.deepcopy(value)
 
     def _is_dirty(self, xblock):

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -640,7 +640,8 @@ def test_get_mutable_mark_dirty():
 
     # Now test after having explicitly set the field.
     mutable_test.save()
-    assert_equals(len(mutable_test._dirty_fields), 0)
+    # _dirty_fields shouldn't be cleared here
+    assert_equals(len(mutable_test._dirty_fields), 1)
     _test_get = mutable_test.list_field
     assert_equals(len(mutable_test._dirty_fields), 1)
 

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -26,9 +26,7 @@ from xblock.fields import (
     UNIQUE_ID
 )
 
-from xblock.test.tools import (
-    assert_equals, assert_not_equals, assert_in, assert_not_in, assert_false, assert_true, TestRuntime
-)
+from xblock.test.tools import assert_equals, assert_not_equals, assert_not_in, TestRuntime
 from xblock.fields import scope_key, ScopeIds
 
 
@@ -544,39 +542,6 @@ def test_twofaced_field_access():
     assert_equals(len(field_tester._dirty_fields), 1)
     # However, the field should not ACTUALLY be marked as a field that is needing to be saved.
     assert_not_in('how_many', field_tester._get_fields_to_save())   # pylint: disable=W0212
-
-
-def test_setting_the_same_value_marks_field_as_dirty():
-    """
-    Check that setting field to the same value does not mark mutable fields as dirty.
-    This might be an unexpected behavior though
-    """
-    class FieldTester(XBlock):
-        """Test block for set - get test."""
-        non_mutable = String(scope=Scope.settings)
-        list_field = List(scope=Scope.settings)
-        dict_field = Dict(scope=Scope.settings)
-
-    runtime = TestRuntime(services={'field-data': DictFieldData({})})
-    field_tester = FieldTester(runtime, scope_ids=Mock(spec=ScopeIds))
-
-    # precondition checks
-    assert_equals(len(field_tester._dirty_fields), 0)
-    assert_false(field_tester.fields['list_field'].is_set_on(field_tester))
-    assert_false(field_tester.fields['dict_field'].is_set_on(field_tester))
-    assert_false(field_tester.fields['non_mutable'].is_set_on(field_tester))
-
-    field_tester.non_mutable = field_tester.non_mutable
-    field_tester.list_field = field_tester.list_field
-    field_tester.dict_field = field_tester.dict_field
-
-    assert_in(field_tester.fields['non_mutable'], field_tester._dirty_fields)
-    assert_in(field_tester.fields['list_field'], field_tester._dirty_fields)
-    assert_in(field_tester.fields['dict_field'], field_tester._dirty_fields)
-
-    assert_true(field_tester.fields['non_mutable'].is_set_on(field_tester))
-    assert_true(field_tester.fields['list_field'].is_set_on(field_tester))
-    assert_true(field_tester.fields['dict_field'].is_set_on(field_tester))
 
 
 class SentinelTest(unittest.TestCase):

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -519,6 +519,7 @@ def test_set_incomparable_fields():
     # (i.e. timezone aware and unaware datetimes), just reset the value.
 
     class FieldTester(XBlock):
+        """Test block for this test."""
         incomparable = Field(scope=Scope.settings)
 
     not_timezone_aware = dt.datetime(2015, 1, 1)

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -25,7 +25,7 @@ particular combination of initial conditions that we want to test)
 """
 
 import copy
-from mock import Mock, patch
+from mock import Mock
 
 from xblock.core import XBlock
 from xblock.fields import Integer, List, String, ScopeIds, UNIQUE_ID
@@ -162,13 +162,6 @@ class UniversalProperties(object):
         self.block.save()
         assert_false(self.field_data.has(self.block, 'field'))
         assert_true(self.is_default())
-
-    def test_set_after_get_always_saves(self):
-        with patch.object(self.field_data, 'set_many') as patched_set_many:
-            self.set(self.get())
-            self.block.save()
-
-            patched_set_many.assert_called_with(self.block, {'field': self.get()})
 
 
 class MutationProperties(object):


### PR DESCRIPTION
@cpennington , not ready for review yet, but I'm running into an issue with this test: https://github.com/edx/XBlock/blob/master/xblock/test/test_core.py#L643

When I pdb through that test, I notice that `mutable_test.list_field` is in the list of dirty_fields, but returns false when `_is_dirty` is run on it.

Any insights into what I'm missing here?