### PR TITLE
return empty string if value is none

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -780,10 +780,18 @@ class String(JSONField):
     MUTABLE = False
 
     def from_json(self, value):
-        if value is None or isinstance(value, basestring):
+        if value is None:
+            return ''
+        elif isinstance(value, basestring):
             return value
         else:
             raise TypeError('Value stored in a String must be None or a string, found %s' % type(value))
+
+    def to_json(self, value):
+        if value is None:
+            return ''
+        self._warn_deprecated_outside_JSONField()
+        return value
 
     def from_string(self, value):
         """String gets serialized and deserialized without quote marks."""

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -212,7 +212,14 @@ class StringTest(FieldTest):
         self.assertJSONOrSetEquals('', '')
 
     def test_none(self):
-        self.assertJSONOrSetEquals(None, None)
+        # test for NoneType for to_string and from_string methods
+        test_field = String(enforce_type=True)
+
+        result_to_string = test_field.to_string(None)
+        self.assertEquals(result_to_string, '')
+
+        result_from_string = test_field.from_string(None)
+        self.assertEquals(result_from_string, '')
 
     def test_error(self):
         self.assertJSONOrSetTypeError(['a'])


### PR DESCRIPTION
[TNL-2686](https://openedx.atlassian.net/browse/TNL-2686)

If the xml attribute is setting using lxml library with ```None``` value then it raises ```TypeError``` ,  instead of passing ```None``` value to ```set(attribute, value)``` function , we can pass ```empty``` string (in case of NoneType) to avoid this error.

Test for the pr are at [#8889](https://github.com/edx/edx-platform/pull/8889)

