### PR TITLE
Make Field.to_string() and Field.from_string() methods more consistent.

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -439,7 +439,11 @@ class Field(Nameable):
                 value, traceback.format_exc().splitlines()[-1])
             warnings.warn(message, FailingEnforceTypeWarning, stacklevel=3)
         else:
-            if value != new_value:
+            try:
+                equal = value == new_value
+            except TypeError:
+                equal = False
+            if not equal:
                 message = u"The value {} would be enforced to {}".format(
                     value, new_value)
                 warnings.warn(message, ModifyingEnforceTypeWarning, stacklevel=3)

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -602,7 +602,7 @@ class Field(Nameable):
         """
         self._warn_deprecated_outside_JSONField()
         value = yaml.safe_load(serialized)
-        return self._check_or_enforce_type(value)
+        return self.enforce_type(value)
 
     def enforce_type(self, value):
         """
@@ -614,7 +614,7 @@ class Field(Nameable):
         This must not have side effects, since it will be executed to trigger
         a DeprecationWarning even if enforce_type is disabled
         """
-        return value
+        return self.from_json(value)
 
     def read_from(self, xblock):
         """
@@ -678,8 +678,6 @@ class Integer(JSONField):
             return None
         return int(value)
 
-    enforce_type = from_json
-
 
 class Float(JSONField):
     """
@@ -696,8 +694,6 @@ class Float(JSONField):
         if value is None or value == '':
             return None
         return float(value)
-
-    enforce_type = from_json
 
 
 class Boolean(JSONField):
@@ -735,8 +731,6 @@ class Boolean(JSONField):
         else:
             return bool(value)
 
-    enforce_type = from_json
-
 
 class Dict(JSONField):
     """
@@ -753,8 +747,6 @@ class Dict(JSONField):
         else:
             raise TypeError('Value stored in a Dict must be None or a dict, found %s' % type(value))
 
-    enforce_type = from_json
-
 
 class List(JSONField):
     """
@@ -770,8 +762,6 @@ class List(JSONField):
             return value
         else:
             raise TypeError('Value stored in a List must be None or a list, found %s' % type(value))
-
-    enforce_type = from_json
 
 
 class Set(JSONField):
@@ -825,8 +815,6 @@ class String(JSONField):
         """String gets serialized and deserialized without quote marks."""
         return self.to_json(value)
 
-    enforce_type = from_json
-
 
 class DateTime(JSONField):
     """
@@ -842,31 +830,27 @@ class DateTime(JSONField):
         """
         Parse the date from an ISO-formatted date string, or None.
         """
-        if isinstance(value, basestring):
-
-            # Parser interprets empty string as now by default
-            if value == "":
-                return None
-
-            try:
-                parsed_date = dateutil.parser.parse(value)
-            except (TypeError, ValueError):
-                raise ValueError("Could not parse {} as a date".format(value))
-
-            if parsed_date.tzinfo is not None:  # pylint: disable=maybe-no-member
-                parsed_date.astimezone(pytz.utc)  # pylint: disable=maybe-no-member
-            else:
-                parsed_date = parsed_date.replace(tzinfo=pytz.utc)  # pylint: disable=maybe-no-member
-
-            return parsed_date
-
         if value is None:
             return None
 
-        if isinstance(value, datetime.datetime):
-            return value
+        if isinstance(value, basestring):
+            # Parser interprets empty string as now by default
+            if value == "":
+                return None
+            try:
+                value = dateutil.parser.parse(value)
+            except (TypeError, ValueError):
+                raise ValueError("Could not parse {} as a date".format(value))
 
-        raise TypeError("Value should be loaded from a string, not {}".format(type(value)))
+        if not isinstance(value, datetime.datetime):
+            raise TypeError(
+                "Value should be loaded from a string, a datetime object or None, not {}".format(type(value))
+            )
+
+        if value.tzinfo is not None:  # pylint: disable=maybe-no-member
+            return value.astimezone(pytz.utc)  # pylint: disable=maybe-no-member
+        else:
+            return value.replace(tzinfo=pytz.utc)  # pylint: disable=maybe-no-member
 
     def to_json(self, value):
         """
@@ -878,11 +862,9 @@ class DateTime(JSONField):
             return None
         raise TypeError("Value stored must be a datetime object, not {}".format(type(value)))
 
-    def enforce_type(self, value):
-        if isinstance(value, datetime.datetime) or value is None:
-            return value
-
-        return self.from_json(value)
+    def to_string(self, value):
+        """DateTime fields get serialized without quote marks."""
+        return self.to_json(value)
 
 
 class Any(JSONField):

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -614,7 +614,7 @@ class Field(Nameable):
         This must not have side effects, since it will be executed to trigger
         a DeprecationWarning even if enforce_type is disabled
         """
-        return self.from_json(value)
+        return value
 
     def read_from(self, xblock):
         """
@@ -678,6 +678,8 @@ class Integer(JSONField):
             return None
         return int(value)
 
+    enforce_type = from_json
+
 
 class Float(JSONField):
     """
@@ -694,6 +696,8 @@ class Float(JSONField):
         if value is None or value == '':
             return None
         return float(value)
+
+    enforce_type = from_json
 
 
 class Boolean(JSONField):
@@ -731,6 +735,8 @@ class Boolean(JSONField):
         else:
             return bool(value)
 
+    enforce_type = from_json
+
 
 class Dict(JSONField):
     """
@@ -747,6 +753,8 @@ class Dict(JSONField):
         else:
             raise TypeError('Value stored in a Dict must be None or a dict, found %s' % type(value))
 
+    enforce_type = from_json
+
 
 class List(JSONField):
     """
@@ -762,6 +770,8 @@ class List(JSONField):
             return value
         else:
             raise TypeError('Value stored in a List must be None or a list, found %s' % type(value))
+
+    enforce_type = from_json
 
 
 class Set(JSONField):
@@ -815,6 +825,8 @@ class String(JSONField):
         """String gets serialized and deserialized without quote marks."""
         return self.to_json(value)
 
+    enforce_type = from_json
+
 
 class DateTime(JSONField):
     """
@@ -865,6 +877,8 @@ class DateTime(JSONField):
     def to_string(self, value):
         """DateTime fields get serialized without quote marks."""
         return self.to_json(value)
+
+    enforce_type = from_json
 
 
 class Any(JSONField):

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -689,6 +689,8 @@ class FieldSerializationTest(unittest.TestCase):
         result = _type().from_string(string)
         self.assertEquals(result, value)
 
+    # Serialisation test data that is tested both ways, i.e. whether serialisation of the value
+    # yields the string and deserialisation of the string yields the value.
     @ddt.unpack
     @ddt.data(
         (Integer, 0, '0'),
@@ -745,6 +747,10 @@ class FieldSerializationTest(unittest.TestCase):
         result = _type().to_string(value)
         self.assertRegexpMatches(result, regexp)
 
+    # Test data for non-canonical serialisations of values that we should be able to correctly
+    # deserialise.  These values are not serialised to the representation given here for various
+    # reasons; some of them are non-standard number representations, others are YAML data that
+    # isn't valid JSON, yet others use non-standard capitalisation.
     @ddt.unpack
     @ddt.data(
         (Integer, "0xff", 0xff),

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -280,9 +280,10 @@ class DateTest(FieldTest):
         """
         Make sure field comparison doesn't crash when comparing naive and non-naive datetimes.
         """
-        block = self.get_block(True)
-        block.field_x = original
-        block.field_x = replacement
+        for enforce_type in (False, True):
+            block = self.get_block(enforce_type)
+            block.field_x = original
+            block.field_x = replacement
 
     def test_none(self):
         self.assertJSONOrSetEquals(None, None)


### PR DESCRIPTION
**Description**

The old version of these methods was inherently assymmetric.  The deserialisation in `from_string()`
only called `from_json()` when `enforce_type()` was overridden to do so (which all classes with a
non-trivial `from_json()` implementation do) and `enable_enforce_type` was set to `True`.  This commit
makes the two functions more consistent by not considering `enable_enforce_type` at all for
deserialisation and calling `from_json()` in `enforce_type()` by default.  Serialisation and
deserialisation requires correct types to work already, so there is no harm in always enforciing
the type – the code fails in the same cases as before.

This commit fixes a bug in serialising `DateTime` fields.  The old version included spurious double
quotes around the string, which would not be correctly deserialised when `enable_enforce_type` was
not set (the default).

This patch was already [commited to the edx-solutions fork](https://github.com/edx-solutions/XBlock/pull/5) of this repostiory.
- - -
 
**JIRA Story** [OSPR-734](https://openedx.atlassian.net/browse/OSPR-734)
**Confluence / Product Asset** N/A
**Sandbox URL** [sandbox3.opencraft.com](http://sandbox3.opencraft.com/) – try importing some exported course tar.gz here, preferably one containing `DateTime` fields.
**Dependencies** N/A
**PR Author(s) Notes / To-Do** N/A
**Screenshots** N/A
- - -
**Reviewers**
- [x] Code: @e-kolpakov (thumbs up given in the [edx-solutions PR](https://github.com/edx-solutions/XBlock/pull/5))
- [ ] Code: (TBD) 
