### PR TITLE
(WIP) Make Field.to_string() and Field.from_string() methods more consistent.

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -440,7 +440,11 @@ class Field(Nameable):
                 value, traceback.format_exc().splitlines()[-1])
             warnings.warn(message, FailingEnforceTypeWarning, stacklevel=3)
         else:
-            if value != new_value:
+            try:
+                equal = value == new_value
+            except TypeError:
+                equal = False
+            if not equal:
                 message = u"The value {} would be enforced to {}".format(
                     value, new_value)
                 warnings.warn(message, ModifyingEnforceTypeWarning, stacklevel=3)

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -12,8 +12,6 @@ import copy
 import datetime
 import dateutil.parser
 import hashlib
-import json
-import dateutil.parser
 import itertools
 import pytz
 import traceback

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -5,12 +5,15 @@ The hosting runtime application decides what actual storage mechanism to use
 for each scope.
 
 """
+import ast
 
 from collections import namedtuple
 import copy
 import datetime
 import dateutil.parser
 import hashlib
+import json
+import dateutil.parser
 import itertools
 import pytz
 import traceback
@@ -652,7 +655,27 @@ class JSONField(Field):
     """
     Field type which has a convenient JSON representation.
     """
-    pass  # for now; we'll bubble functions down when we finish deprecation in Field
+    @classmethod
+    def coerce_value(cls, value, goal_types):
+        """
+        When loading from XML, a more complex data structure may be serialized
+        into a string. Attempt to load the value both from a JSON parser and
+        from an AST literal, since some export functions just run str() on the
+        values.
+
+        If the result is not the right type, throw an error.
+        """
+        try:
+            value = json.loads(value)
+        except ValueError:
+            try:
+                value = ast.literal_eval(value)
+            except (SyntaxError, ValueError):
+                raise TypeError("Could not deserialize string {0}. Please ensure it is valid JSON.".format(repr(value)))
+        if not isinstance(value, goal_types):
+            raise TypeError("Value stored on {0} must be of types: {1}. Found {2}.".format(
+                cls.__name__, repr(goal_types), type(value)))
+        return value
 
 
 class Integer(JSONField):
@@ -746,8 +769,11 @@ class Dict(JSONField):
     def from_json(self, value):
         if value is None or isinstance(value, dict):
             return value
+        elif isinstance(value, basestring):
+            value = self.coerce_value(value, (dict, type(None)))
         else:
             raise TypeError('Value stored in a Dict must be None or a dict, found %s' % type(value))
+        return value
 
     enforce_type = from_json
 
@@ -764,8 +790,11 @@ class List(JSONField):
     def from_json(self, value):
         if value is None or isinstance(value, list):
             return value
+        elif isinstance(value, basestring):
+            value = self.coerce_value(value, (list, type(None)))
         else:
             raise TypeError('Value stored in a List must be None or a list, found %s' % type(value))
+        return value
 
     enforce_type = from_json
 

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -83,6 +83,13 @@ class FieldTest(unittest.TestCase):
         """
         self.assertEqual(expected, self.FIELD_TO_TEST().to_json(arg))
 
+    def assertFromJSONOrLitEquals(self, expected, arg):
+        """
+        Assert that deserialization of `arg` from stringified JSON or
+        Python Literal equals `expected`.
+        """
+        self.assertEqual(expected, self.FIELD_TO_TEST().from_json(arg))
+
     def assertJSONOrSetValueError(self, arg):
         """
         Asserts that field.from_json or setting the field throws a ValueError
@@ -306,6 +313,10 @@ class ListTest(FieldTest):
         self.assertJSONOrSetEquals(['foo', 'bar'], ['foo', 'bar'])
         self.assertJSONOrSetEquals([1, 3.4], [1, 3.4])
 
+    def test_json_lit_coersion(self):
+        self.assertFromJSONOrLitEquals([1, 2, None, "hello"], '[1, 2, null, "hello"]')
+        self.assertFromJSONOrLitEquals([None, 3, 4, True], "[None, 3, 4, True]")
+
     def test_none(self):
         self.assertJSONOrSetEquals(None, None)
 
@@ -370,6 +381,10 @@ class DictTest(FieldTest):
     def test_json_equals(self):
         self.assertJSONOrSetEquals({}, {})
         self.assertJSONOrSetEquals({'a': 'b', 'c': 3}, {'a': 'b', 'c': 3})
+
+    def test_json_lit_coersion(self):
+        self.assertFromJSONOrLitEquals({'d': "e", "f": 4}, '{"d": "e", "f": 4}')
+        self.assertFromJSONOrLitEquals({'g': "h", "i": None}, "{'g': 'h', 'i': None}")
 
     def test_none(self):
         self.assertJSONOrSetEquals(None, None)

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -37,9 +37,9 @@ class FieldTest(unittest.TestCase):
 
     FIELD_TO_TEST = Mock()
 
-    def set_and_get_field(self, arg, enforce_type):
+    def get_block(self, enforce_type):
         """
-        Set the field to arg in a Block, get it and return it
+        Create a block with a field 'field_x' that is of type FIELD_TO_TEST.
         """
         class TestBlock(XBlock):
             """
@@ -48,7 +48,13 @@ class FieldTest(unittest.TestCase):
             field_x = self.FIELD_TO_TEST(enforce_type=enforce_type)
 
         runtime = TestRuntime(services={'field-data': DictFieldData({})})
-        block = TestBlock(runtime, scope_ids=Mock(spec=ScopeIds))
+        return TestBlock(runtime, scope_ids=Mock(spec=ScopeIds))
+
+    def set_and_get_field(self, arg, enforce_type):
+        """
+        Set the field to arg in a Block, get it and return the set value.
+        """
+        block = self.get_block(enforce_type)
         block.field_x = arg
         return block.field_x
 
@@ -230,6 +236,7 @@ class StringTest(FieldTest):
         self.assertJSONOrSetTypeError({})
 
 
+@ddt.ddt
 class DateTest(FieldTest):
     """
     Tests of the Date field.
@@ -264,6 +271,25 @@ class DateTest(FieldTest):
             '2014-04-01T02:03:04.000000',
             dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc)
         )
+
+    @ddt.unpack
+    @ddt.data(
+        (
+            dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc),
+            dt.datetime(2014, 4, 1, 2, 3, 5)
+        ),
+        (
+            dt.datetime(2014, 4, 1, 2, 3, 4),
+            dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc),
+        )
+    )
+    def test_naive(self, original, replacement):
+        """
+        Make sure field comparison doesn't crash when comparing naive and non-naive datetimes.
+        """
+        block = self.get_block(True)
+        block.field_x = original
+        block.field_x = replacement
 
     def test_none(self):
         self.assertJSONOrSetEquals(None, None)

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -640,14 +640,14 @@ class FieldSerializationTest(unittest.TestCase):
         """
         Helper method: checks if _type's to_string given instance of _type returns expected string
         """
-        result = _type(enforce_type=True).to_string(value)
+        result = _type().to_string(value)
         self.assertEquals(result, string)
 
     def assert_from_string(self, _type, string, value):
         """
         Helper method: checks if _type's from_string given string representation of type returns expected value
         """
-        result = _type(enforce_type=True).from_string(string)
+        result = _type().from_string(string)
         self.assertEquals(result, value)
 
     @ddt.unpack
@@ -688,7 +688,10 @@ class FieldSerializationTest(unittest.TestCase):
                 2,
                 3
               ]
-            }""")))
+            }""")),
+        (DateTime, dt.datetime(2014, 4, 1, 2, 3, 4, 567890).replace(tzinfo=pytz.utc), '2014-04-01T02:03:04.567890'),
+        (DateTime, dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc), '2014-04-01T02:03:04.000000'),
+    )
     def test_both_directions(self, _type, value, string):
         """Easy cases that work in both directions."""
         self.assert_to_string(_type, value, string)
@@ -700,7 +703,7 @@ class FieldSerializationTest(unittest.TestCase):
         (Float, 1.0, r"1|1\.0*"),
         (Float, -10.0, r"-10|-10\.0*"))
     def test_to_string_regexp_matches(self, _type, value, regexp):
-        result = _type(enforce_type=True).to_string(value)
+        result = _type().to_string(value)
         self.assertRegexpMatches(result, regexp)
 
     @ddt.unpack
@@ -768,7 +771,11 @@ class FieldSerializationTest(unittest.TestCase):
                   kaw: null
             """),
             [1, 2.345, {"foo": True, "bar": [1, 2, 3]}, {"meow": False, "woof": True, "kaw": None}]
-        )
+        ),
+        # Test that legacy DateTime format including double quotes can still be imported for compatibility with
+        # old data export tar balls.
+        (DateTime, '"2014-04-01T02:03:04.567890"', dt.datetime(2014, 4, 1, 2, 3, 4, 567890).replace(tzinfo=pytz.utc)),
+        (DateTime, '"2014-04-01T02:03:04.000000"', dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc)),
     )
     def test_from_string(self, _type, string, value):
         self.assert_from_string(_type, string, value)
@@ -779,7 +786,7 @@ class FieldSerializationTest(unittest.TestCase):
         This special test case is necessary since
         float('nan') compares inequal to everything.
         """
-        result = Float(enforce_type=True).from_string('NaN')
+        result = Float().from_string('NaN')
         self.assertTrue(math.isnan(result))
 
     @ddt.unpack
@@ -789,4 +796,4 @@ class FieldSerializationTest(unittest.TestCase):
     def test_from_string_errors(self, _type, string):
         """ Cases that raises various exceptions."""
         with self.assertRaises(StandardError):
-            _type(enforce_type=True).from_string(string)
+            _type().from_string(string)


### PR DESCRIPTION
The old version of these methods was inherently assymmetric.  The deserialisation in from_string()
only called from_json() when enforce_type() was overridden to do so (which all classes with a
non-trivial from_json() implementation do) and enable_enforce_type was set to True.  This commit
makes the two functions more consistent by not considering enable_enforce_type at all for
deserialisation and calling from_json() in enforce_type() by default.  Serialisation and
deserialisation requires correct types to work already, so there is no harm in always enforciing
the type – the code fails in the same cases as before.

This commit fixes a bug in serialising DateTime fields.  The old version included spurious double
quotes around the string, which would not be correctly deserialised when enable_enforce_type was
not set (the default).