### PR TITLE
Adding message in XBlockSaveError Exception

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ David Bodor <david.gabor.bodor@gmail.com>
 Dhruv Baldawa <dhruvbaldawa@gmail.com>
 Matjaz Gregoric <mtyaka@gmail.com>
 Adam Palay <adam@edx.org>
+Awais Jibran <awaisdar001@gmail.com>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # 3rd-party needs
+pyyaml
 lxml
 requests
 webob

--- a/xblock/exceptions.py
+++ b/xblock/exceptions.py
@@ -21,7 +21,7 @@ class XBlockSaveError(Exception):
     """
     Raised to indicate an error in saving an XBlock
     """
-    def __init__(self, saved_fields, dirty_fields):
+    def __init__(self, saved_fields, dirty_fields, message=None):
         """
         Create a new XBlockSaveError
 
@@ -30,7 +30,7 @@ class XBlockSaveError(Exception):
         `dirty_fields` - a set of fields that were left dirty after the save
         """
         # Exception is an old-style class, so can't use super
-        Exception.__init__(self)
+        Exception.__init__(self, message)
 
         self.saved_fields = saved_fields
         self.dirty_fields = dirty_fields

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -272,7 +272,8 @@ class ScopedStorageMixin(RuntimeServicesMixin):
                 fields.remove(field)
                 # if the field was dirty, delete from dirty fields
                 self._reset_dirty_field(field)
-            raise XBlockSaveError(saved_fields, fields)
+            msg = 'Error saving fields {}'.format(save_error.saved_field_names)
+            raise XBlockSaveError(saved_fields, fields, msg)
 
         # Remove all dirty fields, since the save was successful
         for field in fields:


### PR DESCRIPTION
[TNL-2324](https://openedx.atlassian.net/browse/TNL-2324)

Adding message in `XBlockSaveError` excception. Current exception in [mixins.py#L275](https://github.com/edx/XBlock/blob/111935cab69a9128948180e6b9673c391d2ff165/xblock/mixins.py#L275) doesn't log the fields on which the error is occurring. 

#### Example of current logging of exception
```
Traceback (most recent call last):
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic-2.46.0.37/newrelic/hooks/framework_django.py", line 499, in wrapper return wrapped(*args, **kwargs)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 945, in handle_xblock_callback return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1064, in _invoke_xblock_handler resp = instance.handle(handler, req, suffix)
File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/mixins.py", line 86, in handle return self.runtime.handle(self, handler_name, request, suffix)
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1274, in handle return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/runtime.py", line 1035, in handle block.save()
File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/mixins.py", line 253, in save self.force_save_fields(fields_to_save)
File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/mixins.py", line 275, in force_save_fields raise XBlockSaveError(saved_fields, fields)
XBlockSaveError
```

When there will be an error (e.g. `DatabaseError` in [lms/djangoapps/courseware/model_data.py#L421-L428](https://github.com/edx/edx-platform/blob/062e979e0ed14161d0f882091a06e032ca76bb3e/lms/djangoapps/courseware/model_data.py#L421-L428) and `KeyValueMultiSaveError`  exceptions is raised, we can excact the following logging. 

Example of logging after change
-
#### Code
```
raise KeyValueMultiSaveError(['error_field'])
```
####  Log
```
    self.force_save_fields(fields_to_save)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/mixins.py", line 277, in force_save_fields
    raise XBlockSaveError(saved_fields, fields, msg)
XBlockSaveError: Error saving fields ['error_field']
```