### PR TITLE
Force export runtime option + some tests for XmlSerializationMixin

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -298,6 +298,9 @@ class Field(Nameable):
         xml_node: if set, the field will be serialized as a
             separate node instead of an xml attribute (default: False).
 
+        force_export: if set, the field value will be exported to XML even if normal
+            export conditions are not met (i.e. the field has no explicit value set)
+
         kwargs: optional runtime-specific options/metadata. Will be stored as
             runtime_options.
 
@@ -308,7 +311,7 @@ class Field(Nameable):
     # We're OK redefining built-in `help`
     def __init__(self, help=None, default=UNSET, scope=Scope.content,  # pylint:disable=redefined-builtin
                  display_name=None, values=None, enforce_type=False,
-                 xml_node=False, **kwargs):
+                 xml_node=False, force_export=False, **kwargs):
         self.warned = False
         self.help = help
         self._enable_enforce_type = enforce_type
@@ -322,6 +325,7 @@ class Field(Nameable):
         self._values = values
         self.runtime_options = kwargs
         self.xml_node = xml_node
+        self.force_export = force_export
 
     @property
     def default(self):

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -480,7 +480,7 @@ class XmlSerializationMixin(ScopedStorageMixin):
         for field_name, field in self.fields.iteritems():
             if field_name in ('children', 'parent', 'content'):
                 continue
-            if field.is_set_on(self) or field.runtime_options.get('force_export', False):
+            if field.is_set_on(self) or field.force_export:
                 self._add_field(node, field_name, field)
 
         # Add children for each of our children.

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -477,7 +477,7 @@ class XmlSerializationMixin(ScopedStorageMixin):
         for field_name, field in self.fields.iteritems():
             if field_name in ('children', 'parent', 'content'):
                 continue
-            if field.is_set_on(self):
+            if field.is_set_on(self) or field.runtime_options.get('force_export', False):
                 self._add_field(node, field_name, field)
 
         # Add children for each of our children.

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -8,6 +8,7 @@ import inspect
 import logging
 from lxml import etree
 import copy
+from collections import OrderedDict
 
 try:
     import simplesjson as json  # pylint: disable=F0401
@@ -22,10 +23,12 @@ from xblock.fields import Field, Reference, Scope, ReferenceList
 from xblock.internal import class_lazy, NamedAttributesMetaclass
 
 
-XML_NAMESPACES = {
-    "option": "http://code.edx.org/xblock/option",
-    "block": "http://code.edx.org/xblock/block",
-}
+# OrderedDict is used so that namespace attributes are put in predictable order
+# This allows for simple string equality assertions in tests and have no other effects
+XML_NAMESPACES = OrderedDict([
+    ("option", "http://code.edx.org/xblock/option"),
+    ("block", "http://code.edx.org/xblock/block"),
+])
 
 
 class HandlersMixin(object):

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -220,6 +220,7 @@ class TestXmlSerializationMixin(TestCase):
 
     etree_node_tag = 'test_xblock'
 
+    # pylint:disable=invalid-name
     class TestXBlock(XBlock):
         """ XBlock for XML export test """
         field = String()
@@ -231,10 +232,11 @@ class TestXmlSerializationMixin(TestCase):
     def _make_block(self):
         """ Creates a test block """
         runtime_mock = mock.Mock(spec=Runtime)
-        scope_ids = ScopeIds("user_id", self.etree_node_tag, "def_id",  "usage_id")
+        scope_ids = ScopeIds("user_id", self.etree_node_tag, "def_id", "usage_id")
         return self.TestXBlock(runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids)
 
     def _assert_node_attributes(self, node, attributes):
+        """ Asserts node attributes """
         node_attributes = node.keys()
         node_attributes.remove('xblock-family')
 
@@ -249,6 +251,7 @@ class TestXmlSerializationMixin(TestCase):
                 self.assertIsNotNone(node.get(key))
 
     def test_add_xml_to_node(self):
+        """ Tests add_xml_to_node with various field defaults and runtime parameters """
         block = self._make_block()
         node = etree.Element(self.etree_node_tag)
 


### PR DESCRIPTION
**Description:** This PR adds an option to force export any field. Forward-port of https://github.com/edx-solutions/XBlock/pull/6

The motivation is the following: `UNIQUE_ID` sentinel is used to generate a unique pseudo-random value for an XBlock field. The value generated is not actually random, and is stable (i.e. subsequent calculations return same value for given field and XBlock instances). The problem though, is that this value is not persisted in export-import workflow.

Direct motivation, more details and discussion of various approaches can be seen in the appropriate [JIRA task](https://edx-wiki.atlassian.net/browse/MCKIN-3637)

**JIRA Task:** [MCKIN-3637](https://edx-wiki.atlassian.net/browse/MCKIN-3637) and [OSPR-970](https://openedx.atlassian.net/browse/OSPR-970)
**Testing instructions:** 
No user facing parts - running unittests should be enough.

For manual verification:
1. Create an XBlock with any field that have `default=UNIQUE_ID` and `force_export=True` (or use existing one, i.e. https://github.com/open-craft/xblock-group-project-v2). 
2. Create a course, add that XBlock to course content, *do not specify a value for that field - leave it default*, but note the value somehow (i.e. display it in the student view)
3. Export course.
4. Import course. Observe the value was preserved.