### PR TITLE
Making filesystem part of core XBlocks

### DIFF
--- a/django_requirements.txt
+++ b/django_requirements.txt
@@ -1,3 +1,4 @@
 # Install Django requirements, if we're using the optional Django-integrated
 # parts of XBlock
 Django >= 1.8, < 1.9
+django-pyfs

--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -6,3 +6,5 @@ Fields API
 
 .. automodule:: xblock.fields
     :members:
+.. autoclass:: xblock.reference.plugins.Filesystem
+    :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ cookiecutter
 
 # Our own XBlocks
 -e .
+
+# pyfilesystem
+fs

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ setup(
         'python-dateutil',
         'pytz',
         'webob',
+        'fs',
     ],
+    extras_require={
+        'django': ['django-pyfs']
+    },
     license='Apache 2.0',
     classifiers=(
         "License :: OSI Approved :: Apache Software License 2.0",

--- a/xblock/reference/plugins.py
+++ b/xblock/reference/plugins.py
@@ -8,23 +8,37 @@ Much of this still needs to be organized.
 """
 
 try:
+    from django.core.exceptions import ImproperlyConfigured
+except ImportError:
+    class ImproperlyConfigured(Exception):
+        '''
+        If Django is installed, and djpyfs is installed, but we're not in a
+        Django app, we'll get this exception. We'd like to catch
+        it. But we don't want the try/except to fail even if we're
+        either in a proper Django app, or don't have Django installed
+        at all.
+        '''
+        pass
+
+try:
     from djpyfs import djpyfs  # pylint: disable=import-error
 except ImportError:
+    djpyfs = None  # pylint: disable=invalid-name
+except ImproperlyConfigured:
+    print "Warning! Django is not correctly configured."
     djpyfs = None  # pylint: disable=invalid-name
 
 from xblock.fields import Field, NO_CACHE_VALUE
 from xblock.fields import scope_key
 
 #  Finished services
-#    None yet
-#
-#  edX-internal prototype services
 
 
 def public(type=None, **kwargs):  # pylint: disable=unused-argument, redefined-builtin
     """
-    Mark a function as public. In the future, this will inform the XBlocks services
-    framework to make the function remotable. For now, this is a placeholder.
+    Mark a function as public. In the future, this will inform the
+    XBlocks services framework to make the function remotable. For
+    now, this is a placeholder.
 
     The kwargs will contain:
 
@@ -53,21 +67,23 @@ def public(type=None, **kwargs):  # pylint: disable=unused-argument, redefined-b
 class Service(object):
     """
     Top-level definition for an XBlocks service.
-    This is intended as a starting point for discussion, not a finished interface.
+
+    This is intended as a starting point for discussion, not
+    necessarily a finished interface.
 
     Possible goals:
-
-    * Right now, they derive from object. We'd like there to be a common superclass.
-    * We'd like to be able to provide both language-level and service-level bindings.
-    * We'd like them to have a basic knowledge of context (what block they're being
-      called from, access to the runtime, dependencies, etc.
-    * That said, we'd like to not over-initialize. Services may have expensive
-      initializations, and a per-block initialization may be prohibitive.
-    * We'd like them to be able to load through Stevedor, and have a plug-in
-      mechanism similar to XBlock.
-
-    This superclass should go somewhere else. This is an interrim location until we
-    figure out where.
+    * Right now, they derive from object. We'd like there to be a
+      common superclass.
+    * We'd like to be able to provide both language-level and
+      service-level bindings.
+    * We'd like them to have a basic knowledge of context (what block
+      they're being called from, access to the runtime, dependencies,
+      etc.
+    * That said, we'd like to not over-initialize. Services may have
+      expensive initializations, and a per-block initialization may be
+      prohibitive.
+    * We'd like them to be able to load through Stevedor, and have a
+      plug-in mechanism similar to XBlock.
     """
     def __init__(self, **kwargs):
         # TODO: We need plumbing to set these
@@ -88,67 +104,38 @@ class Service(object):
         return self._runtime
 
 
-if djpyfs:
-    class FSService(Service):
-        """
-        This is a PROTOTYPE service for storing files in XBlock fields.
-
-        It returns a file system as per:
-          https://github.com/pmitros/django-pyfs
-
-        1) The way this service is initialized and used is likely
-        wrong. We'll want to fix it.
-        2) There is discussion as to whether we want this service at
-        all. Specifically:
-        - It is unclear if XBlocks ought to have filesystem-as-a-service,
-          or just as a field, as per below. Below requires an FS service,
-          but it is not clear XBlocks should know about it.
-
-        - It is unclear if pyfilesystem has performance properties we
-          want.  Our goal is to try this in a limited roll-out, and see if
-          whether we run into limitations, and if so, which ones. This is
-          not intended as part of the XBlock standard until we've built up
-          more experience and comfort with it. See:
-
-          https://groups.google.com/forum/#!topic/edx-code/4VadWwqeMNI
-        """
-
-        @public()
-        def load(self, instance, xblock):
-            """
-            Get the filesystem for the field specified in 'instance' and the xblock in 'xblock'
-            It is locally scoped.
-            """
-            # TODO: Get xblock from context, once the plumbing is piped through
-            return djpyfs.get_filesystem(scope_key(instance, xblock))
-
-        def __repr__(self):
-            return "File system object"
-
-
 class Filesystem(Field):
-    """
-    An enhanced pyfilesystem.
+    """An enhanced pyfilesystem.
 
     This returns a file system provided by the runtime. The file
     system has two additional methods over a normal pyfilesytem:
-    1) get_url allows it to return a reference to a file on said
-    filesystem
-    2) expire allows it to create files which may be garbage
-    collected after a preset period.
 
-    This is a PROTOTYPE intended for limited roll-out. See comments
-    in FSService above.
+    * `get_url` allows it to return a URL for a file
+    * `expire` allows it to create files which may be garbage
+      collected after a preset period. `edx-platform` and
+      `xblock-sdk` do not currently garbage collect them,
+      however.
+
+    More information can be found at: http://docs.pyfilesystem.org/en/latest/
+    and https://github.com/pmitros/django-pyfs
+
+    The major use cases for this are storage of large binary objects,
+    pregenerating per-student data (e.g. `pylab` plots), and storing
+    data which should be downloadable (for example, serving <img
+    src=...> will typically be faster through this than serving that
+    up through XBlocks views.
     """
     MUTABLE = False
 
     def __get__(self, xblock, xblock_class):
         """
-        Gets the value of this xblock. Prioritizes the cached value over
-        obtaining the value from the field-data service. Thus if a cached value
-        exists, that is the value that will be returned. Otherwise, it
-        will get it from the fs service.
+        Returns a `pyfilesystem` object which may be interacted with.
         """
+        # Prioritizes the cached value over obtaining the value from
+        # the field-data service. Thus if a cached value exists, that
+        # is the value that will be returned. Otherwise, it will get
+        # it from the fs service.
+
         # pylint: disable=protected-access
         if xblock is None:
             return self
@@ -162,12 +149,58 @@ class Filesystem(Field):
 
     def __delete__(self, xblock):
         """
-        We don't support this until we figure out what this means
+        We don't support this until we figure out what this means. Files
+        should be deleted through normal pyfilesystem operations.
         """
         raise NotImplementedError
 
     def __set__(self, xblock, value):
         """
-        We don't support this until we figure out what this means
+        We interact with a file system by `open`/`close`/`read`/`write`,
+        not `set` and `get`.
+
+        We don't support this until we figure out what this means. In
+        the future, this might be used to e.g. store some kind of
+        metadata about the file system in the KVS (perhaps prefix and
+        location or similar?)
         """
         raise NotImplementedError
+
+#  edX-internal prototype services
+
+
+class FSService(Service):
+    """
+    This is a PROTOTYPE service for storing files in XBlock fields.
+
+    It returns a file system as per:
+    https://github.com/pmitros/django-pyfs
+
+    1) We want to change how load() works, and specifically how
+    prefixes are calculated.
+    2) There is discussion as to whether we want this service at
+    all. Specifically:
+    - It is unclear if XBlocks ought to have filesystem-as-a-service,
+      or just as a field, as per below. Below requires an FS service,
+      but it is not clear XBlocks should know about it.
+    """
+    @public()
+    def load(self, instance, xblock):
+        """
+        Get the filesystem for the field specified in 'instance' and the
+        xblock in 'xblock' It is locally scoped.
+        """
+
+        # TODO: Get xblock from context, once the plumbing is piped through
+        if djpyfs:
+            return djpyfs.get_filesystem(scope_key(instance, xblock))
+        else:
+            # The reference implementation relies on djpyfs
+            # https://github.com/edx/django-pyfs
+            # For Django runtimes, you may use this reference
+            # implementation. Otherwise, you will need to
+            # patch pyfilesystem yourself to implement get_url.
+            raise NotImplementedError("djpyfs not available")
+
+    def __repr__(self):
+        return "File system object"


### PR DESCRIPTION
This PR makes pyfilesystem *field* support into a supported feature.

It explicitly does *not* mark the associated XBlock *service* API production-quality.

It is a minimal PR. It adds djpyfs as a dependency. It removes code for handling when it is not there. It removes comments marking this as prototype. It slightly shifts things around in the file to move the service as not finalized, but the field as finalized.

@cpennington @nedbat @ormsbee Would any two of you care to give this a thumbs up?