### PR TITLE
Fixing exporting DateTime with value set to None

### DIFF
--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -522,6 +522,10 @@ class XmlSerializationMixin(ScopedStorageMixin):
         as an xml attribute or creates a separate child node.
         """
         value = field.to_string(field.read_from(self))
+
+        if value is None:
+            value = ""
+
         if field.xml_node:
             tag = etree.QName(XML_NAMESPACES["option"], field_name)
             elem = node.makeelement(tag)

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -693,6 +693,13 @@ class FieldSerializationTest(unittest.TestCase):
     # yields the string and deserialisation of the string yields the value.
     @ddt.unpack
     @ddt.data(
+        (DateTime, None, None)
+    )
+    def test_to_string(self, _type, value, string):
+        self.assert_to_string(_type, value, string)
+
+    @ddt.unpack
+    @ddt.data(
         (Integer, 0, '0'),
         (Integer, 5, '5'),
         (Integer, -1023, '-1023'),
@@ -821,6 +828,7 @@ class FieldSerializationTest(unittest.TestCase):
         # old data export tar balls.
         (DateTime, '"2014-04-01T02:03:04.567890"', dt.datetime(2014, 4, 1, 2, 3, 4, 567890).replace(tzinfo=pytz.utc)),
         (DateTime, '"2014-04-01T02:03:04.000000"', dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc)),
+        (DateTime, '', None),
     )
     def test_from_string(self, _type, string, value):
         self.assert_from_string(_type, string, value)

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -228,9 +228,9 @@ class TestXmlSerializationMixin(TestCase):
         etree_node_tag = 'test_xblock'
 
         field = String()
-        simple_default = String(default="default")
-        force_export = String(default="default", force_export=True)
-        unique_id_default = String(default=UNIQUE_ID)
+        simple = String(default="default")
+        simple_force_export = String(default="default", force_export=True)
+        unique_id = String(default=UNIQUE_ID)
         unique_id_force_export = String(default=UNIQUE_ID, force_export=True)
 
     class TestXBlockWithDateTime(XBlock):
@@ -273,13 +273,13 @@ class TestXmlSerializationMixin(TestCase):
         block.add_xml_to_node(node)
 
         self._assert_node_attributes(
-            node, {'force_export': 'default', 'unique_id_force_export': UNIQUE_ID}
+            node, {'simple_force_export': 'default', 'unique_id_force_export': UNIQUE_ID}
         )
 
         block.field = 'Value1'
-        block.simple_default = 'Value2'
-        block.force_export = 'Value3'
-        block.unique_id_default = 'Value4'
+        block.simple = 'Value2'
+        block.simple_force_export = 'Value3'
+        block.unique_id = 'Value4'
         block.unique_id_force_export = 'Value5'
 
         block.add_xml_to_node(node)
@@ -288,9 +288,9 @@ class TestXmlSerializationMixin(TestCase):
             node,
             {
                 'field': 'Value1',
-                'simple_default': 'Value2',
-                'force_export': 'Value3',
-                'unique_id_default': 'Value4',
+                'simple': 'Value2',
+                'simple_force_export': 'Value3',
+                'unique_id': 'Value4',
                 'unique_id_force_export': 'Value5',
             }
         )


### PR DESCRIPTION
**Description:** forward-port of corresponding [solutions PR](https://github.com/edx-solutions/XBlock/pull/7). It is possible to set DateTime field to None (and not default), but exporting the course would fail in that case. This PR fixes this.

**JIRA:** [OSPR-1038](https://openedx.atlassian.net/browse/OSPR-1038)

**Testing Instructions:**
1. Create an XBlock with DateTime field (or use existing one).
2. (Optional) Using StudioEditableXBlockMixin from xblock-utils makes it much easier by providing declarative interface to specifying what fields should be edited.
3. In studio, add the block to a course.
4. Set DateTime field to empty value (if using StudioEditableXBlockMixin - set any value with datetime dropdown, than clear it with backspace/delete. Do **not** reset to default.
5. Try exporting the course. *Pre-fix behavior:* Exception is thrown. *Expected behavior:* Course is successfully exported.