### PR TITLE
Fix XBlockAside.add_xml_to_node crash

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,3 +36,4 @@ Dhruv Baldawa <dhruvbaldawa@gmail.com>
 Matjaz Gregoric <mtyaka@gmail.com>
 Adam Palay <adam@edx.org>
 Awais Jibran <awaisdar001@gmail.com>
+Dmitry Viskov <dmitry.viskov@webenterprise.ru>

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -183,6 +183,14 @@ class XBlock(XmlSerializationMixin, HierarchyMixin, ScopedStorageMixin, RuntimeS
         runtime_ugettext = runtime_service.ugettext
         return runtime_ugettext(text)
 
+    def add_xml_to_node(self, node):
+        """
+        For exporting, set data on etree.Element `node`.
+        """
+        super(XBlock, self).add_xml_to_node(node)
+        # Add children for each of our children.
+        self.add_children_to_node(node)
+
 
 class XBlockAside(XmlSerializationMixin, ScopedStorageMixin, RuntimeServicesMixin, HandlersMixin, SharedBlockBase):
     """

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -413,6 +413,15 @@ class HierarchyMixin(ScopedStorageMixin):
         """
         self._child_cache.clear()
 
+    def add_children_to_node(self, node):
+        """
+        Add children to etree.Element `node`.
+        """
+        if self.has_children:
+            for child_id in self.children:
+                child = self.runtime.get_block(child_id)
+                self.runtime.add_block_as_child_node(child, node)
+
 
 class XmlSerializationMixin(ScopedStorageMixin):
     """
@@ -482,12 +491,6 @@ class XmlSerializationMixin(ScopedStorageMixin):
                 continue
             if field.is_set_on(self) or field.force_export:
                 self._add_field(node, field_name, field)
-
-        # Add children for each of our children.
-        if self.has_children:
-            for child_id in self.children:
-                child = self.runtime.get_block(child_id)
-                self.runtime.add_block_as_child_node(child, node)
 
         # A content field becomes text content.
         text = self.xml_text_content()


### PR DESCRIPTION
This PR is related with the conversation: https://github.com/edx/edx-platform/pull/11808#discussion_r56330814

`has_children` attribute is set in [ChildrenModelMetaclass](https://github.com/edx/XBlock/blob/master/xblock/mixins.py#L333) metaclass. `ChildrenModelMetaclass` is metaclass for [HierarchyMixin](https://github.com/edx/XBlock/blob/master/xblock/mixins.py#L355). `XBlock` inherits `HierarchyMixin`:
```
class XBlock(XmlSerializationMixin, HierarchyMixin, ScopedStorageMixin,
RuntimeServicesMixin, HandlersMixin, IndexInfoMixin, ViewsMixin, SharedBlockBase):
```
but `XBlockAside` isn't:
```
class XBlockAside(XmlSerializationMixin, ScopedStorageMixin, 
RuntimeServicesMixin, HandlersMixin, SharedBlockBase):
```
The `self.has_children` check is used in `XmlSerializationMixin.add_xml_to_node` function.