### PR TITLE
Expose the configured resources_dir via get_resources_dir.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='XBlock',
-    version='0.4.8',
+    version='0.4.9',
     description='XBlock Core Library',
     packages=[
         'xblock',

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -54,6 +54,10 @@ class SharedBlockBase(Plugin):
     resources_dir = 'public'
 
     @classmethod
+    def get_resources_dir(cls):
+        return cls.resources_dir
+
+    @classmethod
     def open_local_resource(cls, uri):
         """Open a local resource.
 


### PR DESCRIPTION
This builds on #340 and actually exposes a method to check the configured resources directory of a given XBlock.