### PR TITLE
Add a way to stream unprotected local resources.

### DIFF
--- a/xblock/core.py
+++ b/xblock/core.py
@@ -103,6 +103,16 @@ class SharedBlockBase(Plugin):
         if "/." in uri:
             raise DisallowedFileError("Only safe file names are allowed: %r" % uri)
 
+        return cls.stream_local_resource(uri)
+
+    @classmethod
+    def stream_local_resource(cls, uri):
+        """
+        Stream a local resources.
+
+        This is a helper method to get a file-like handle to a local resource
+        while adjusting URIs based on the resource configuration of this XBlock.
+        """
         return pkg_resources.resource_stream(cls.__module__, os.path.join(cls.resources_dir, uri))
 
 

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -918,7 +918,7 @@ class OpenLocalResourceTest(unittest.TestCase):
         pass
 
     class UnloadableXBlock(XBlock):
-        """Just something to load resources from."""
+        """Just something to (not) load resources from."""
         resources_dir = None
 
     def stub_resource_stream(self, module, name):


### PR DESCRIPTION
Depending on whether or not you're in a production environment, you may want to be able to stream all resources from a given XBlock.  This happens, in particular, when edx-platform is running in debug mode, and all resources are required individually, instead of being bundled up.

Instead of requiring consumers to do their own pkg_resources lookups to sidestep open_local_resource's 'public' restriction, we now have a method that allows this to happen in a controlled way from the XBlock itself, which takes into consideration things like a custom resources_dir configuration, etc.