### PR TITLE
Fix xblock requirements & non abstract FieldData method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # 3rd-party needs
 pyyaml
 lxml
-requests
 webob>=1.6.0
 simplejson
 pytz

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'markupsafe',
         'python-dateutil',
         'pytz',
+        'pyyaml',
         'webob',
         'fs',
     ],

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -63,7 +63,6 @@ class FieldData(object):
         """
         raise NotImplementedError
 
-    @abstractmethod
     def has(self, block, name):
         """
         Return whether or not the field named `name` has a non-default value for the XBlock `block`.


### PR DESCRIPTION
1. The 'pyyaml requirement is undeclared in setup.py
2. 'requests' is declared in 'requirements.txt' while it is in fact unused 
3. The 'has' method of the FieldData class should not be considered as abstract