### PR TITLE
Remove control characters in XBlock String fields.

### DIFF
--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -69,7 +69,7 @@ class FieldTest(unittest.TestCase):
             if issubclass(warning.category, DeprecationWarning)
         ))
 
-    def assertJSONOrSetEquals(self, expected, arg):
+    def assertJSONOrSetGetEquals(self, expected, arg):
         """
         Asserts the result of field.from_json and of setting field.
         """
@@ -77,6 +77,12 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(expected, self.FIELD_TO_TEST().from_json(arg))
         # set+get with enforce_type arg -> expected
         self.assertEqual(expected, self.set_and_get_field(arg, True))
+
+    def assertJSONOrSetEquals(self, expected, arg):
+        """
+        Asserts the result of field.from_json and of setting field.
+        """
+        self.assertJSONOrSetGetEquals(expected, arg)
         # set+get without enforce_type arg -> arg
         # provoking a warning unless arg == expected
         count = 0 if arg == expected else 1
@@ -227,6 +233,15 @@ class StringTest(FieldTest):
         self.assertJSONOrSetTypeError([1])
         self.assertJSONOrSetTypeError([])
         self.assertJSONOrSetTypeError({})
+
+    def test_control_characters_filtered(self):
+        self.assertJSONOrSetGetEquals(u'', u'\v')
+        self.assertJSONOrSetGetEquals('', '\v')
+        with self.assertRaises(AssertionError):
+            self.assertJSONOrSetGetEquals('\v', u'')
+        with self.assertRaises(AssertionError):
+            self.assertJSONOrSetGetEquals(u'\v', '')
+        self.assertJSONOrSetGetEquals(u'\n\r\t', u'\n\v\r\b\t')
 
 
 @ddt.ddt


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-1031

If a control character exists in an XBlock String field that is then sent to XML, a ValueError is raised. This error blocks a course with control characters in video display_names (for example) from being exported. A simple example of the problem:
```
>>> from lxml import etree
>>> xml = etree.Element('my_element')
>>> string_field = u'Control Characters: "What to do \vabout them?"'
>>> string_field
u'Control Characters: "What to do \x0babout them?"'
>>> xml.set('my_attr', string_field)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lxml.etree.pyx", line 744, in lxml.etree._Element.set (src/lxml/lxml.etree.c:44335)
  File "apihelpers.pxi", line 554, in lxml.etree._setAttributeValue (src/lxml/lxml.etree.c:19531)
  File "apihelpers.pxi", line 1393, in lxml.etree._utf8 (src/lxml/lxml.etree.c:27125)
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
```
I've implemented a solution in this PR which removes invalid XML characters during the `__set__` of a String field - and also removes the characters upon a `__get__` of the field. It uses a general `_sanitize` method that any field can implement if needed.

The downsides to this solution:
- The invalid XML characters are removed silently and are a side-effect of setting/getting the field value, which can be confusing to a user.
- There are places in code (tests at least) that check object equality between what is set and gotten later. The code returns the original string if no changes have occurred - but creates/uses a new str/unicode object if it needs to remove characters.

Alternatives:
- Use XML character references to preserve the control characters in an XML export - and then restore the characters upon import. This solution would make the string above be written to XML like this: `u'Control Characters: "What to do &#11;about them?"'`. However, I don't see much value in preserving these unprintable characters in String fields.
- Raise a ValueError upon `__set__` of a String field with control characters - and deal with the existing cases via modifying course data to remove the characters -or- removing them in code during a String field's `__get__` like the code in this PR does.

Accompanying edx-platform PR (to test the change):
https://github.com/edx/edx-platform/pull/12893

@cpennington @jmbowman @adampalay @macdiesel Please review.