### PR TITLE
Bump version number from 0.4.10 to 0.4.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='XBlock',
-    version='0.4.10',
+    version='0.4.11',
     description='XBlock Core Library',
     packages=[
         'xblock',


### PR DESCRIPTION
Bump XBlock module version number to release the changes merged in this PR: 
https://github.com/edx/XBlock/pull/351
Forgot to add a version bump to the PR above - oops.

@macdiesel @jmbowman Please review.