### PR TITLE
Python3: Futurize!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ local_settings.py
 .coverage
 htmlcov
 *~
+.tox
+MANIFEST
 
 # Documentation
 doc/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,19 @@ branches:
       - master
 python:
   - "2.7"
+  - "3.5"
 cache: pip
 install:
-  - pip install -r requirements.txt
-  - pip install -r django_requirements.txt
+  - pip install tox
   - pip install coveralls
 script:
   - make test doc quality
 after_success:
   - coveralls
+env:
+  - TOXENV=djangoNA
+  - TOXENV=django14
+  - TOXENV=django15
+  - TOXENV=django16
+  - TOXENV=django17
+  - TOXENV=django18

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.5"
 cache: pip
 install:
+  - pip install -r test-requirements.txt
   - pip install tox
   - pip install coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,4 @@ after_success:
   - coveralls
 env:
   - TOXENV=djangoNA
-  - TOXENV=django14
-  - TOXENV=django15
-  - TOXENV=django16
-  - TOXENV=django17
   - TOXENV=django18

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ docs:
 	cd doc && make html
 
 quality:
-	pep8 --exclude=.tox
-	script/max_pylint_violations
+	tox -e py27-quality py35-quality
 
 package:
 	python setup.py register sdist upload

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docs:
 	cd doc && make html
 
 quality:
-	pep8
+	pep8 --exclude=.tox
 	script/max_pylint_violations
 
 package:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	coverage run -m nose
+	tox
 
 docs:
 	cd doc && make html

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docs:
 	cd doc && make html
 
 quality:
-	tox -e py27-quality py35-quality
+	tox -e py27-quality -e py35-quality
 
 package:
 	python setup.py register sdist upload

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import unicode_literals
 import sys
 import os
 from path import path

--- a/pylintrc
+++ b/pylintrc
@@ -12,7 +12,7 @@ profile=no
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS, migrations
+ignore=CVS, migrations, .tox
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/pylintrc
+++ b/pylintrc
@@ -19,7 +19,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=caniusepython3.pylint_checker
 
 
 [MESSAGES CONTROL]
@@ -46,6 +46,7 @@ disable=
     star-args,
     abstract-class-not-used,
     abstract-class-little-used,
+    abstract-class-instantiated,
     no-init,
     too-many-lines,
     no-self-use,
@@ -56,7 +57,8 @@ disable=
     too-many-return-statements,
     too-many-branches,
     too-many-arguments,
-    too-many-locals
+    too-many-locals,
+    duplicate-code,
 
 
 [REPORTS]
@@ -146,6 +148,8 @@ no-docstring-rgx=__.*__|test_.+|setUp|tearDown
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=-1
+
+extension-pkg-whitelist=lxml
 
 
 [FORMAT]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,11 @@ markupsafe
 mock
 nose
 coverage
-# pinning astroid b/c it's throwing errors on 2.7.8 altho doc says it shouldn't
-astroid == 1.2.1
-pylint == 1.3.1
+astroid
+pylint
 rednose
 pep8
+caniusepython3
 diff-cover >= 0.2.1
 ddt==0.8.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # 3rd-party needs
+future
 pyyaml
 lxml
 webob>=1.6.0

--- a/script/max_pylint_violations
+++ b/script/max_pylint_violations
@@ -1,5 +1,5 @@
 #!/bin/bash
-DEFAULT_MAX=$15
+DEFAULT_MAX=15
 
 pylint xblock | tee /tmp/pylint-xblock.log
 ERR=`grep -E "^[C|R|W|E]:" /tmp/pylint-xblock.log | wc -l`

--- a/script/max_pylint_violations
+++ b/script/max_pylint_violations
@@ -1,10 +1,10 @@
 #!/bin/bash
-DEFAULT_MAX=11
+DEFAULT_MAX=$15
 
 pylint xblock | tee /tmp/pylint-xblock.log
 ERR=`grep -E "^[C|R|W|E]:" /tmp/pylint-xblock.log | wc -l`
 MAX=${1-$DEFAULT_MAX}
-if [ $ERR -ge $MAX ]; then
+if [ $ERR -gt $MAX ]; then
     echo "too many pylint violations: $ERR (max is $MAX)"
     exit 1
 else

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'xblock.test.django',
     ],
     install_requires=[
+        'future',
         'lxml',
         'markupsafe',
         'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,9 @@ setup(
     license='Apache 2.0',
     classifiers=(
         "License :: OSI Approved :: Apache Software License 2.0",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Set up for XBlock"""
+from __future__ import unicode_literals
 from setuptools import setup
 
 setup(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,13 +1,3 @@
-# 3rd-party needs
-future
-pyyaml
-lxml
-webob>=1.6.0
-simplejson
-pytz
-python-dateutil
-markupsafe
-
 # For Tests
 mock
 nose

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,7 @@ pep8
 caniusepython3
 diff-cover >= 0.2.1
 ddt==0.8.0
+tox
 
 # For docs
 -r doc/requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,14 +1,14 @@
 # For Tests
+astroid
+caniusepython3
+coverage
+ddt==0.8.0
+diff-cover >= 0.2.1
 mock
 nose
-coverage
-astroid
+pep8
 pylint
 rednose
-pep8
-caniusepython3
-diff-cover >= 0.2.1
-ddt==0.8.0
 tox
 
 # For docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,20 @@
 [tox]
-envlist = py{27,35}-django{NA,18}
+envlist = py{27,35}-test-django{NA,18}, py{27,35}-quality
 skip_missing_interpreters=true
 
 [testenv]
 deps = -rtest-requirements.txt
     django18: Django>=1.8,<1.9
+
+[testenv:test]
 commands = coverage run -m nose
+
+[testenv:py27-quality]
+commands = pep8 --exclude=.tox,doc
+           {toxinidir}/script/max_pylint_violations
+
+[testenv:py35-quality]
+commands = pep8 --exclude=.tox,doc
+           {toxinidir}/script/max_pylint_violations
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34}-django{NA,14,15,16,17,18}
+envlist = py{27,34}-django{NA,14,17,18}
 skip_missing_interpreters=true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{27,35}-test-django{NA,18}, py{27,35}-quality
+envlist = py{27,35}-test-django{NA,18}
 skip_missing_interpreters=true
 
 [testenv]
 deps = -rtest-requirements.txt
     django18: Django>=1.8,<1.9
+    quality: Django>=1.8,<1.9
 
 [testenv:test]
 commands = coverage run -m nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
-envlist = py{27,34}-django{NA,14,17,18}
+envlist = py{27,35}-django{NA,18}
 skip_missing_interpreters=true
 
 [testenv]
 deps = -rtest-requirements.txt
-    django14: Django>=1.4,<1.5
-    django15: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
 commands = coverage run -m nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{27,34}-django{NA,14,15,16,17,18}
+skip_missing_interpreters=true
+
+[testenv]
+deps = -rtest-requirements.txt
+    django14: Django>=1.4,<1.5
+    django15: Django>=1.5,<1.6
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+commands = coverage run -m nose

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,10 @@ commands = coverage run -m nose
 
 [testenv:py27-quality]
 commands = pep8 --exclude=.tox,doc
-           {toxinidir}/script/max_pylint_violations
+           {toxinidir}/script/max_pylint_violations 15
 
 [testenv:py35-quality]
 commands = pep8 --exclude=.tox,doc
-           {toxinidir}/script/max_pylint_violations
+           {toxinidir}/script/max_pylint_violations 22
 
 

--- a/xblock/__init__.py
+++ b/xblock/__init__.py
@@ -1,6 +1,7 @@
 """
 XBlock Courseware Components
 """
+from __future__ import unicode_literals
 
 # For backwards compatability, provide the XBlockMixin in xblock.fields
 # without causing a circular import

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -6,7 +6,7 @@ and used by all runtimes.
 
 """
 from __future__ import unicode_literals
-from builtins import bytes
+from builtins import bytes  # pylint: disable=redefined-builtin
 import future.utils
 
 import inspect

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -287,7 +287,7 @@ class XBlockAside(XmlSerializationMixin, ScopedStorageMixin, RuntimeServicesMixi
         If all of the aside's data is empty or a default value, then the aside shouldn't
         be serialized as XML at all.
         """
-        return any([field.is_set_on(self) for field in self.fields.itervalues()])
+        return any(field.is_set_on(self) for field in self.fields.values())
 
 
 # Maintain backwards compatibility

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -7,14 +7,14 @@ and used by all runtimes.
 """
 from __future__ import unicode_literals
 from builtins import bytes  # pylint: disable=redefined-builtin
-import future.utils
 
 import inspect
-import pkg_resources
 import warnings
 import os
 from collections import defaultdict
 
+import future.utils
+import pkg_resources
 from xblock.exceptions import DisallowedFileError
 from xblock.fields import String, List, Scope
 from xblock.internal import class_lazy
@@ -30,6 +30,9 @@ from xblock.mixins import (
 )
 from xblock.plugin import Plugin
 from xblock.validation import Validation
+
+# This is imported just to re-expose exceptions that were moved into that file
+import xblock.exceptions
 
 # exposing XML_NAMESPACES as a member of core, in order to avoid importing mixins where
 # XML_NAMESPACES are needed (e.g. runtime.py).
@@ -295,10 +298,6 @@ class XBlockAside(XmlSerializationMixin, ScopedStorageMixin, RuntimeServicesMixi
         be serialized as XML at all.
         """
         return any(field.is_set_on(self) for field in future.utils.itervalues(self.fields))
-
-
-# Maintain backwards compatibility
-import xblock.exceptions
 
 
 class KeyValueMultiSaveError(xblock.exceptions.KeyValueMultiSaveError):

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -5,6 +5,9 @@ This code is in the Runtime layer, because it is authored once by edX
 and used by all runtimes.
 
 """
+from builtins import bytes
+import future.utils
+
 import inspect
 import pkg_resources
 import warnings
@@ -89,6 +92,9 @@ class SharedBlockBase(Plugin):
         matched against a whitelist regex to ensure that you do not serve an
         unauthorized resource.
         """
+
+        if isinstance(uri, bytes):
+            uri = uri.decode('utf-8')
 
         # If no resources_dir is set, then this XBlock cannot serve local resources.
         if cls.resources_dir is None:
@@ -287,7 +293,7 @@ class XBlockAside(XmlSerializationMixin, ScopedStorageMixin, RuntimeServicesMixi
         If all of the aside's data is empty or a default value, then the aside shouldn't
         be serialized as XML at all.
         """
-        return any(field.is_set_on(self) for field in self.fields.values())
+        return any(field.is_set_on(self) for field in future.utils.itervalues(self.fields))
 
 
 # Maintain backwards compatibility

--- a/xblock/core.py
+++ b/xblock/core.py
@@ -5,6 +5,7 @@ This code is in the Runtime layer, because it is authored once by edX
 and used by all runtimes.
 
 """
+from __future__ import unicode_literals
 from builtins import bytes
 import future.utils
 

--- a/xblock/django/__init__.py
+++ b/xblock/django/__init__.py
@@ -1,3 +1,4 @@
 """
 Contains utilities for integrating XBlock with Django.
 """
+from __future__ import unicode_literals

--- a/xblock/django/request.py
+++ b/xblock/django/request.py
@@ -1,12 +1,13 @@
 """Helpers for WebOb requests and responses."""
 from __future__ import unicode_literals
 from builtins import zip, object  # pylint: disable=redefined-builtin
-import future.utils
 
-import webob
 from collections import MutableMapping
-from lazy import lazy
 from itertools import chain, repeat
+
+import future.utils
+from lazy import lazy
+import webob
 from webob.multidict import MultiDict, NestedMultiDict, NoVars
 
 

--- a/xblock/django/request.py
+++ b/xblock/django/request.py
@@ -1,9 +1,11 @@
 """Helpers for WebOb requests and responses."""
+from builtins import zip
+from builtins import object
 
 import webob
 from collections import MutableMapping
 from lazy import lazy
-from itertools import chain, repeat, izip
+from itertools import chain, repeat
 from webob.multidict import MultiDict, NestedMultiDict, NoVars
 
 
@@ -77,7 +79,7 @@ def querydict_to_multidict(query_dict, wrap=None):
     """
     wrap = wrap or (lambda val: val)
     return MultiDict(chain.from_iterable(
-        izip(repeat(key), (wrap(v) for v in vals))
+        list(zip(repeat(key), (wrap(v) for v in vals)))
         for key, vals in query_dict.iterlists()
     ))
 

--- a/xblock/django/request.py
+++ b/xblock/django/request.py
@@ -1,7 +1,6 @@
 """Helpers for WebOb requests and responses."""
 from __future__ import unicode_literals
-from builtins import zip
-from builtins import object
+from builtins import zip, object  # pylint: disable=redefined-builtin
 import future.utils
 
 import webob

--- a/xblock/django/request.py
+++ b/xblock/django/request.py
@@ -1,6 +1,7 @@
 """Helpers for WebOb requests and responses."""
 from builtins import zip
 from builtins import object
+import future.utils
 
 import webob
 from collections import MutableMapping
@@ -78,9 +79,15 @@ def querydict_to_multidict(query_dict, wrap=None):
 
     """
     wrap = wrap or (lambda val: val)
+
+    if future.utils.PY2:
+        item_lists = query_dict.iterlists()
+    else:
+        item_lists = query_dict.lists()
+
     return MultiDict(chain.from_iterable(
-        list(zip(repeat(key), (wrap(v) for v in vals)))
-        for key, vals in query_dict.iterlists()
+        zip(repeat(key), (wrap(v) for v in vals))
+        for key, vals in item_lists
     ))
 
 

--- a/xblock/django/request.py
+++ b/xblock/django/request.py
@@ -1,4 +1,5 @@
 """Helpers for WebOb requests and responses."""
+from __future__ import unicode_literals
 from builtins import zip
 from builtins import object
 import future.utils

--- a/xblock/exceptions.py
+++ b/xblock/exceptions.py
@@ -1,6 +1,7 @@
 """
 Module for all xblock exception classes
 """
+from __future__ import unicode_literals
 from webob import Response
 try:
     import simplejson as json   # pylint: disable=F0401

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -4,6 +4,7 @@ data to particular scoped fields by name. This allows individual runtimes to
 provide varied persistence backends while keeping the API used by the `XBlock`
 simple.
 """
+from __future__ import unicode_literals
 from builtins import object
 import future.utils
 

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -5,7 +5,7 @@ provide varied persistence backends while keeping the API used by the `XBlock`
 simple.
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 import future.utils
 
 import copy

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -4,6 +4,7 @@ data to particular scoped fields by name. This allows individual runtimes to
 provide varied persistence backends while keeping the API used by the `XBlock`
 simple.
 """
+from builtins import object
 
 import copy
 
@@ -11,14 +12,13 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
 from xblock.exceptions import InvalidScopeError
+from future.utils import with_metaclass
 
 
-class FieldData(object):
+class FieldData(with_metaclass(ABCMeta, object)):
     """
     An interface allowing access to an XBlock's field values indexed by field names.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def get(self, block, name):
@@ -87,7 +87,7 @@ class FieldData(object):
         :param update_dict: A map of field names to their new values
         :type update_dict: dict
         """
-        for key, value in update_dict.items():
+        for key, value in list(update_dict.items()):
             self.set(block, key, value)
 
     def default(self, block, name):  # pylint: disable=unused-argument
@@ -161,9 +161,9 @@ class SplitFieldData(FieldData):
 
     def set_many(self, block, update_dict):
         update_dicts = defaultdict(dict)
-        for key, value in update_dict.items():
+        for key, value in list(update_dict.items()):
             update_dicts[self._field_data(block, key)][key] = value
-        for field_data, update_dict in update_dicts.items():
+        for field_data, update_dict in list(update_dicts.items()):
             field_data.set_many(block, update_dict)
 
     def delete(self, block, name):

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -6,13 +6,12 @@ simple.
 """
 from __future__ import unicode_literals
 from builtins import object  # pylint: disable=redefined-builtin
-import future.utils
-
-import copy
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+import copy
 
+import future.utils
 from xblock.exceptions import InvalidScopeError
 
 

--- a/xblock/field_data.py
+++ b/xblock/field_data.py
@@ -5,6 +5,7 @@ provide varied persistence backends while keeping the API used by the `XBlock`
 simple.
 """
 from builtins import object
+import future.utils
 
 import copy
 
@@ -12,10 +13,9 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
 from xblock.exceptions import InvalidScopeError
-from future.utils import with_metaclass
 
 
-class FieldData(with_metaclass(ABCMeta, object)):
+class FieldData(future.utils.with_metaclass(ABCMeta, object)):
     """
     An interface allowing access to an XBlock's field values indexed by field names.
     """
@@ -87,7 +87,7 @@ class FieldData(with_metaclass(ABCMeta, object)):
         :param update_dict: A map of field names to their new values
         :type update_dict: dict
         """
-        for key, value in list(update_dict.items()):
+        for key, value in future.utils.iteritems(update_dict):
             self.set(block, key, value)
 
     def default(self, block, name):  # pylint: disable=unused-argument
@@ -161,9 +161,9 @@ class SplitFieldData(FieldData):
 
     def set_many(self, block, update_dict):
         update_dicts = defaultdict(dict)
-        for key, value in list(update_dict.items()):
+        for key, value in future.utils.iteritems(update_dict):
             update_dicts[self._field_data(block, key)][key] = value
-        for field_data, update_dict in list(update_dicts.items()):
+        for field_data, update_dict in future.utils.iteritems(update_dicts):
             field_data.set_many(block, update_dict)
 
     def delete(self, block, name):

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -7,20 +7,21 @@ for each scope.
 """
 from __future__ import unicode_literals
 from builtins import str, zip, object  # pylint: disable=redefined-builtin
-import future.utils
 
 from collections import namedtuple
 import copy
 import datetime
-import dateutil.parser
 import hashlib
 import itertools
-import pytz
 import traceback
 import warnings
 import json
-import yaml
 import unicodedata
+import yaml
+
+import dateutil.parser
+import future.utils
+import pytz
 
 from xblock.internal import Nameable
 
@@ -349,7 +350,7 @@ class Field(Nameable):
     def name(self):
         """Returns the name of this field."""
         # This is set by ModelMetaclass
-        return self.__name__ or 'unknown'
+        return self.__name__ or 'unknown'  # pylint: disable=no-member
 
     @property
     def values(self):

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -5,6 +5,7 @@ The hosting runtime application decides what actual storage mechanism to use
 for each scope.
 
 """
+from __future__ import unicode_literals
 from builtins import str
 from builtins import zip
 from past.builtins import basestring

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -5,6 +5,10 @@ The hosting runtime application decides what actual storage mechanism to use
 for each scope.
 
 """
+from builtins import str
+from builtins import zip
+from past.builtins import basestring
+from builtins import object
 
 from collections import namedtuple
 import copy
@@ -839,7 +843,7 @@ class String(JSONField):
         https://www.w3.org/TR/xml/#charsets
         Leave all other characters.
         """
-        if isinstance(value, unicode):
+        if isinstance(value, str):
             new_value = u''.join(ch for ch in value if unicodedata.category(ch)[0] != u'C' or ch in (u'\n', u'\r', u'\t'))
         elif isinstance(value, str):
             new_value = ''.join(ch for ch in value if ord(ch) >= 32 or ch in ('\n', '\r', '\t'))
@@ -1013,23 +1017,23 @@ def scope_key(instance, xblock):
     if instance.scope.user == UserScope.NONE or instance.scope.user == UserScope.ALL:
         pass
     elif instance.scope.user == UserScope.ONE:
-        scope_key_dict['user'] = unicode(xblock.scope_ids.user_id)
+        scope_key_dict['user'] = str(xblock.scope_ids.user_id)
     else:
         raise NotImplementedError()
 
     if instance.scope.block == BlockScope.TYPE:
-        scope_key_dict['block'] = unicode(xblock.scope_ids.block_type)
+        scope_key_dict['block'] = str(xblock.scope_ids.block_type)
     elif instance.scope.block == BlockScope.USAGE:
-        scope_key_dict['block'] = unicode(xblock.scope_ids.usage_id)
+        scope_key_dict['block'] = str(xblock.scope_ids.usage_id)
     elif instance.scope.block == BlockScope.DEFINITION:
-        scope_key_dict['block'] = unicode(xblock.scope_ids.def_id)
+        scope_key_dict['block'] = str(xblock.scope_ids.def_id)
     elif instance.scope.block == BlockScope.ALL:
         pass
     else:
         raise NotImplementedError()
 
     replacements = list(itertools.product("._-", "._-"))
-    substitution_list = dict(zip("./\\,_ +:-", ("".join(x) for x in replacements)))
+    substitution_list = dict(list(zip("./\\,_ +:-", ("".join(x) for x in replacements))))
     # Above runs in 4.7us, and generates a list of common substitutions:
     # {' ': '_-', '+': '-.', '-': '--', ',': '_.', '/': '._', '.': '..', ':': '-_', '\\': '.-', '_': '__'}
 

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -6,10 +6,7 @@ for each scope.
 
 """
 from __future__ import unicode_literals
-from builtins import str
-from builtins import zip
-from past.builtins import basestring
-from builtins import object
+from builtins import str, zip, object  # pylint: disable=redefined-builtin
 import future.utils
 
 from collections import namedtuple

--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -9,6 +9,7 @@ from builtins import str
 from builtins import zip
 from past.builtins import basestring
 from builtins import object
+import future.utils
 
 from collections import namedtuple
 import copy
@@ -157,6 +158,7 @@ UNSET = Sentinel("fields.UNSET")
 ScopeBase = namedtuple('ScopeBase', 'user block name')
 
 
+@future.utils.python_2_unicode_compatible
 class Scope(ScopeBase):
     """
     Defines six types of scopes to be used: `content`, `settings`,
@@ -231,11 +233,14 @@ class Scope(ScopeBase):
     children = Sentinel('Scope.children')
     parent = Sentinel('Scope.parent')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def __eq__(self, other):
         return isinstance(other, Scope) and self.user == other.user and self.block == other.block
+
+    def __hash__(self):
+        return hash((u'xblock.fields.Scope', self.user, self.block))
 
 
 class ScopeIds(namedtuple('ScopeIds', 'user_id block_type def_id usage_id')):
@@ -469,7 +474,7 @@ class Field(Nameable):
         for the field in its given scope.
         """
         key = scope_key(self, xblock)
-        return hashlib.sha1(key).hexdigest()
+        return hashlib.sha1(key.encode('utf-8')).hexdigest()
 
     def _get_default_value_to_cache(self, xblock):
         """
@@ -756,7 +761,10 @@ class Boolean(JSONField):
                                       **kwargs)
 
     def from_json(self, value):
-        if isinstance(value, basestring):
+        if isinstance(value, bytes):
+            value = value.decode('ascii', errors='replace')
+
+        if isinstance(value, str):
             return value.lower() == 'true'
         else:
             return bool(value)
@@ -778,6 +786,18 @@ class Dict(JSONField):
             return value
         else:
             raise TypeError('Value stored in a Dict must be None or a dict, found %s' % type(value))
+
+    def to_string(self, value):
+        """
+        In python3, json.dumps() cannot sort keys of different types,
+        so preconvert None to 'null'.
+        """
+        self.enforce_type(value)
+        if isinstance(value, dict) and None in value:
+            value = value.copy()
+            value['null'] = value[None]
+            del value[None]
+        return super(Dict, self).to_string(value)
 
     enforce_type = from_json
 
@@ -843,10 +863,11 @@ class String(JSONField):
         https://www.w3.org/TR/xml/#charsets
         Leave all other characters.
         """
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
+
         if isinstance(value, str):
-            new_value = u''.join(ch for ch in value if unicodedata.category(ch)[0] != u'C' or ch in (u'\n', u'\r', u'\t'))
-        elif isinstance(value, str):
-            new_value = ''.join(ch for ch in value if ord(ch) >= 32 or ch in ('\n', '\r', '\t'))
+            new_value = u''.join(ch for ch in value if unicodedata.category(ch)[0] != u'C' or ch in u'\n\r\t')
         else:
             return value
         # The new string will be equivalent to the original string if no control characters are present.
@@ -854,7 +875,7 @@ class String(JSONField):
         return value if value == new_value else new_value
 
     def from_json(self, value):
-        if value is None or isinstance(value, basestring):
+        if value is None or isinstance(value, (bytes, str)):
             return self._sanitize(value)
         else:
             raise TypeError('Value stored in a String must be None or a string, found %s' % type(value))
@@ -865,6 +886,8 @@ class String(JSONField):
 
     def to_string(self, value):
         """String gets serialized and deserialized without quote marks."""
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
         return self.to_json(value)
 
     @property
@@ -892,7 +915,10 @@ class DateTime(JSONField):
         if value is None:
             return None
 
-        if isinstance(value, basestring):
+        if isinstance(value, bytes):
+            value = value.decode('utf-8')
+
+        if isinstance(value, str):
             # Parser interprets empty string as now by default
             if value == "":
                 return None
@@ -1032,8 +1058,8 @@ def scope_key(instance, xblock):
     else:
         raise NotImplementedError()
 
-    replacements = list(itertools.product("._-", "._-"))
-    substitution_list = dict(list(zip("./\\,_ +:-", ("".join(x) for x in replacements))))
+    replacements = itertools.product("._-", "._-")
+    substitution_list = dict(zip("./\\,_ +:-", ("".join(x) for x in replacements)))
     # Above runs in 4.7us, and generates a list of common substitutions:
     # {' ': '_-', '+': '-.', '-': '--', ',': '_.', '/': '._', '.': '..', ':': '-_', '\\': '.-', '_': '__'}
 
@@ -1042,7 +1068,7 @@ def scope_key(instance, xblock):
     def encode(char):
         """
         Replace all non-alphanumeric characters with -n- where n
-        is their UTF8 code.
+        is their Unicode codepoint.
         TODO: Test for UTF8 which is not ASCII
         """
         if char.isalnum():

--- a/xblock/fragment.py
+++ b/xblock/fragment.py
@@ -3,6 +3,7 @@
 This code is in the Runtime layer.
 
 """
+from __future__ import unicode_literals
 from builtins import object, str
 
 from collections import namedtuple

--- a/xblock/fragment.py
+++ b/xblock/fragment.py
@@ -3,7 +3,7 @@
 This code is in the Runtime layer.
 
 """
-from builtins import object
+from builtins import object, str
 
 from collections import namedtuple
 

--- a/xblock/fragment.py
+++ b/xblock/fragment.py
@@ -3,6 +3,7 @@
 This code is in the Runtime layer.
 
 """
+from builtins import object
 
 from collections import namedtuple
 
@@ -86,7 +87,7 @@ class Fragment(object):
         that it is the only content on the page.
 
         """
-        assert isinstance(content, unicode)
+        assert isinstance(content, str)
         self.content += content
 
     def _default_placement(self, mimetype):

--- a/xblock/fragment.py
+++ b/xblock/fragment.py
@@ -4,7 +4,7 @@ This code is in the Runtime layer.
 
 """
 from __future__ import unicode_literals
-from builtins import object, str
+from builtins import object, str  # pylint: disable=redefined-builtin
 
 from collections import namedtuple
 

--- a/xblock/internal.py
+++ b/xblock/internal.py
@@ -1,6 +1,7 @@
 """
 Internal machinery used to make building XBlock family base classes easier.
 """
+from __future__ import unicode_literals
 from builtins import object
 import future.utils
 

--- a/xblock/internal.py
+++ b/xblock/internal.py
@@ -3,10 +3,11 @@ Internal machinery used to make building XBlock family base classes easier.
 """
 from __future__ import unicode_literals
 from builtins import object  # pylint: disable=redefined-builtin
-import future.utils
 
 import functools
 import inspect
+
+import future.utils
 
 
 class LazyClassProperty(object):

--- a/xblock/internal.py
+++ b/xblock/internal.py
@@ -1,6 +1,7 @@
 """
 Internal machinery used to make building XBlock family base classes easier.
 """
+from builtins import object
 import functools
 import inspect
 
@@ -38,7 +39,7 @@ class NamedAttributesMetaclass(type):
     def __new__(mcs, name, bases, attrs):
         # Iterate over the attrs before they're bound to the class
         # so that we don't accidentally trigger any __get__ methods
-        for attr_name, attr in attrs.iteritems():
+        for attr_name, attr in list(attrs.items()):
             if Nameable.needs_name(attr):
                 attr.__name__ = attr_name
 

--- a/xblock/internal.py
+++ b/xblock/internal.py
@@ -2,6 +2,8 @@
 Internal machinery used to make building XBlock family base classes easier.
 """
 from builtins import object
+import future.utils
+
 import functools
 import inspect
 
@@ -39,7 +41,7 @@ class NamedAttributesMetaclass(type):
     def __new__(mcs, name, bases, attrs):
         # Iterate over the attrs before they're bound to the class
         # so that we don't accidentally trigger any __get__ methods
-        for attr_name, attr in list(attrs.items()):
+        for attr_name, attr in future.utils.iteritems(attrs):
             if Nameable.needs_name(attr):
                 attr.__name__ = attr_name
 
@@ -61,12 +63,10 @@ class Nameable(object):
     """
     __slots__ = ('__name__')
 
-    __name__ = None
-
     @staticmethod
     def needs_name(obj):
         """
         Return True if `obj` is a :class:`.Nameable` object that
         hasn't yet been assigned a name.
         """
-        return isinstance(obj, Nameable) and obj.__name__ is None
+        return isinstance(obj, Nameable) and getattr(obj, '__name__', None) is None

--- a/xblock/internal.py
+++ b/xblock/internal.py
@@ -2,7 +2,7 @@
 Internal machinery used to make building XBlock family base classes easier.
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 import future.utils
 
 import functools

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -3,8 +3,8 @@ This module defines all of the Mixins that provide components of XBlock-family
 functionality, such as ScopeStorage, RuntimeServices, and Handlers.
 """
 from __future__ import unicode_literals
-from past.builtins import basestring
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
+from past.builtins import basestring  # pylint: disable=redefined-builtin
 import future.utils
 
 import functools

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -2,6 +2,7 @@
 This module defines all of the Mixins that provide components of XBlock-family
 functionality, such as ScopeStorage, RuntimeServices, and Handlers.
 """
+from __future__ import unicode_literals
 from past.builtins import basestring
 from builtins import object
 import future.utils

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -4,19 +4,19 @@ functionality, such as ScopeStorage, RuntimeServices, and Handlers.
 """
 from __future__ import unicode_literals
 from builtins import object  # pylint: disable=redefined-builtin
-from past.builtins import basestring  # pylint: disable=redefined-builtin
-import future.utils
 
-import functools
-import inspect
-import logging
-from lxml import etree
 import copy
 from collections import OrderedDict
-
+import functools
+import inspect
 import json
+import logging
 import warnings
 
+import future.utils
+from past.builtins import basestring  # pylint: disable=redefined-builtin
+
+from lxml import etree
 from webob import Response
 
 from xblock.exceptions import JsonHandlerError, KeyValueMultiSaveError, XBlockSaveError, FieldDataDeprecationWarning
@@ -157,7 +157,7 @@ class RuntimeServicesMixin(object):
         Returns:
             One of "need", "want", or None.
         """
-        return cls._combined_services.get(service_name)
+        return cls._combined_services.get(service_name)  # pylint: disable=no-member
 
 
 @RuntimeServicesMixin.needs('field-data')

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -4,6 +4,7 @@ functionality, such as ScopeStorage, RuntimeServices, and Handlers.
 """
 from past.builtins import basestring
 from builtins import object
+import future.utils
 
 import functools
 import inspect
@@ -20,7 +21,6 @@ from webob import Response
 from xblock.exceptions import JsonHandlerError, KeyValueMultiSaveError, XBlockSaveError, FieldDataDeprecationWarning
 from xblock.fields import Field, Reference, Scope, ReferenceList
 from xblock.internal import class_lazy, NamedAttributesMetaclass
-from future.utils import with_metaclass
 
 
 # OrderedDict is used so that namespace attributes are put in predictable order
@@ -160,7 +160,7 @@ class RuntimeServicesMixin(object):
 
 
 @RuntimeServicesMixin.needs('field-data')
-class ScopedStorageMixin(with_metaclass(NamedAttributesMetaclass, RuntimeServicesMixin)):
+class ScopedStorageMixin(future.utils.with_metaclass(NamedAttributesMetaclass, RuntimeServicesMixin)):
     """
     This mixin provides scope for Fields and the associated Scoped storage.
     """
@@ -310,7 +310,7 @@ class ScopedStorageMixin(with_metaclass(NamedAttributesMetaclass, RuntimeService
         # Since this is not understood by static analysis, silence this error.
         # pylint: disable=E1101
         attrs = []
-        for field in list(self.fields.values()):
+        for field in future.utils.itervalues(self.fields):
             try:
                 value = getattr(self, field.name)
             except Exception:  # pylint: disable=W0703
@@ -347,7 +347,7 @@ class ChildrenModelMetaclass(ScopedStorageMixin.__class__):
         return super(ChildrenModelMetaclass, mcs).__new__(mcs, name, bases, attrs)
 
 
-class HierarchyMixin(with_metaclass(ChildrenModelMetaclass, ScopedStorageMixin)):
+class HierarchyMixin(future.utils.with_metaclass(ChildrenModelMetaclass, ScopedStorageMixin)):
     """
     This adds Fields for parents and children.
     """
@@ -463,7 +463,7 @@ class XmlSerializationMixin(ScopedStorageMixin):
                 block.runtime.add_node_as_child(block, child, id_generator)
 
         # Attributes become fields.
-        for name, value in list(node.items()):
+        for name, value in node.items():
             cls._set_field_if_present(block, name, value, {})
 
         # Text content becomes "content", if such a field exists.
@@ -486,7 +486,7 @@ class XmlSerializationMixin(ScopedStorageMixin):
         node.set('xblock-family', self.entry_point)
 
         # Set node attributes based on our fields.
-        for field_name, field in sorted(self.fields.items()):
+        for field_name, field in sorted(future.utils.iteritems(self.fields)):
             if field_name in ('children', 'parent', 'content'):
                 continue
             if field.is_set_on(self) or field.force_export:

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -486,7 +486,7 @@ class XmlSerializationMixin(ScopedStorageMixin):
         node.set('xblock-family', self.entry_point)
 
         # Set node attributes based on our fields.
-        for field_name, field in list(self.fields.items()):
+        for field_name, field in sorted(self.fields.items()):
             if field_name in ('children', 'parent', 'content'):
                 continue
             if field.is_set_on(self) or field.force_export:

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -443,6 +443,8 @@ class XmlSerializationMixin(ScopedStorageMixin):
                 runtime to generate correct definition and usage ids for
                 children of this block.
 
+        Returns (XBlock): The newly parsed XBlock
+
         """
         block = runtime.construct_xblock_from_class(cls, keys)
 

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -3,6 +3,7 @@
 This code is in the Runtime layer.
 
 """
+from builtins import object
 
 import functools
 import itertools

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -3,6 +3,7 @@
 This code is in the Runtime layer.
 
 """
+from __future__ import unicode_literals
 from builtins import object
 
 import functools

--- a/xblock/plugin.py
+++ b/xblock/plugin.py
@@ -4,7 +4,7 @@ This code is in the Runtime layer.
 
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 
 import functools
 import itertools

--- a/xblock/reference/__init__.py
+++ b/xblock/reference/__init__.py
@@ -3,3 +3,4 @@ XBlocks Reference Implementations
 
 See README.md for details.
 """
+from __future__ import unicode_literals

--- a/xblock/reference/plugins.py
+++ b/xblock/reference/plugins.py
@@ -6,6 +6,7 @@ The README file in this directory contains much more information.
 
 Much of this still needs to be organized.
 """
+from __future__ import print_function
 
 try:
     from django.core.exceptions import ImproperlyConfigured
@@ -25,7 +26,7 @@ try:
 except ImportError:
     djpyfs = None  # pylint: disable=invalid-name
 except ImproperlyConfigured:
-    print "Warning! Django is not correctly configured."
+    print("Warning! Django is not correctly configured.")
     djpyfs = None  # pylint: disable=invalid-name
 
 from xblock.fields import Field, NO_CACHE_VALUE

--- a/xblock/reference/plugins.py
+++ b/xblock/reference/plugins.py
@@ -8,7 +8,7 @@ Much of this still needs to be organized.
 """
 from __future__ import print_function
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 
 try:
     from django.core.exceptions import ImproperlyConfigured

--- a/xblock/reference/plugins.py
+++ b/xblock/reference/plugins.py
@@ -7,6 +7,7 @@ The README file in this directory contains much more information.
 Much of this still needs to be organized.
 """
 from __future__ import print_function
+from builtins import object
 
 try:
     from django.core.exceptions import ImproperlyConfigured

--- a/xblock/reference/plugins.py
+++ b/xblock/reference/plugins.py
@@ -7,6 +7,7 @@ The README file in this directory contains much more information.
 Much of this still needs to be organized.
 """
 from __future__ import print_function
+from __future__ import unicode_literals
 from builtins import object
 
 try:

--- a/xblock/reference/user_service.py
+++ b/xblock/reference/user_service.py
@@ -1,6 +1,7 @@
 """
 This file supports the XBlock service that returns data about users.
 """
+from __future__ import unicode_literals
 from builtins import object
 
 from xblock.reference.plugins import Service

--- a/xblock/reference/user_service.py
+++ b/xblock/reference/user_service.py
@@ -2,7 +2,7 @@
 This file supports the XBlock service that returns data about users.
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 
 from xblock.reference.plugins import Service
 

--- a/xblock/reference/user_service.py
+++ b/xblock/reference/user_service.py
@@ -1,6 +1,7 @@
 """
 This file supports the XBlock service that returns data about users.
 """
+from builtins import object
 
 from xblock.reference.plugins import Service
 

--- a/xblock/run_script.py
+++ b/xblock/run_script.py
@@ -13,6 +13,6 @@ def run_script(pycode):
 
     # execute it.
     globs = {}
-    exec pycode in globs, globs  # pylint: disable=W0122
+    exec(pycode, globs, globs)  # pylint: disable=W0122
 
     return globs

--- a/xblock/run_script.py
+++ b/xblock/run_script.py
@@ -1,4 +1,5 @@
 """Script execution for script fragments in content."""
+from __future__ import unicode_literals
 
 import textwrap
 

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -2,9 +2,7 @@
 Machinery to make the common case easy when building new runtimes
 """
 from __future__ import unicode_literals
-from builtins import next
-from builtins import range
-from builtins import object
+from builtins import next, range, object  # pylint: disable=redefined-builtin
 import future.utils
 
 import functools

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -1,6 +1,7 @@
 """
 Machinery to make the common case easy when building new runtimes
 """
+from __future__ import unicode_literals
 from builtins import next
 from builtins import range
 from builtins import object

--- a/xblock/runtime.py
+++ b/xblock/runtime.py
@@ -3,21 +3,23 @@ Machinery to make the common case easy when building new runtimes
 """
 from __future__ import unicode_literals
 from builtins import next, range, object  # pylint: disable=redefined-builtin
-import future.utils
 
+from abc import ABCMeta, abstractmethod
+from collections import namedtuple
 import functools
 import gettext
 import itertools
-import markupsafe
+from io import StringIO, BytesIO
+import json
+import logging
 import re
 import threading
 import warnings
 
-from abc import ABCMeta, abstractmethod
+import future.utils
 from lxml import etree
-from io import StringIO, BytesIO
+import markupsafe
 
-from collections import namedtuple
 from xblock.fields import Field, BlockScope, Scope, ScopeIds, UserScope
 from xblock.field_data import FieldData
 from xblock.fragment import Fragment
@@ -31,8 +33,6 @@ from xblock.exceptions import (
 )
 from xblock.core import XBlock, XBlockAside, XML_NAMESPACES
 
-import logging
-import json
 
 log = logging.getLogger(__name__)
 

--- a/xblock/test/__init__.py
+++ b/xblock/test/__init__.py
@@ -1,3 +1,4 @@
 """
 Tests for XBlock
 """
+from __future__ import unicode_literals

--- a/xblock/test/django/__init__.py
+++ b/xblock/test/django/__init__.py
@@ -1,3 +1,4 @@
 """
 Tests for Django integration with XBlock
 """
+from __future__ import unicode_literals

--- a/xblock/test/django/test_request.py
+++ b/xblock/test/django/test_request.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 # Set up Django settings
 import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "xblock.test.settings")
+from unittest import TestCase
 
 # Django isn't always available, so skip tests if it isn't.
 from nose.plugins.skip import SkipTest
@@ -17,10 +17,12 @@ try:
 except ImportError:
     HAS_DJANGO = False
 
-from unittest import TestCase
 from webob import Response
 
 from xblock.django.request import django_to_webob_request, webob_to_django_response
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "xblock.test.settings")
 
 
 class TestDjangoWebobRequest(TestCase):

--- a/xblock/test/django/test_request.py
+++ b/xblock/test/django/test_request.py
@@ -3,6 +3,7 @@ Test the xblock.django.request module, which provides helper functionality for
 converting django requests to webob requests and webob responses to django
 responses.
 """
+from __future__ import unicode_literals
 
 # Set up Django settings
 import os

--- a/xblock/test/django/test_request.py
+++ b/xblock/test/django/test_request.py
@@ -38,10 +38,10 @@ class TestDjangoWebobRequest(TestCase):
         dj_req = self.req_factory.post('dummy_url', data={'foo': 'bar'})
 
         # Read from POST before constructing the webob request
-        self.assertEquals(dj_req.POST.getlist('foo'), ['bar'])  # pylint: disable=no-member
+        self.assertEqual(dj_req.POST.getlist('foo'), ['bar'])  # pylint: disable=no-member
 
         webob_req = django_to_webob_request(dj_req)
-        self.assertEquals(webob_req.POST.getall('foo'), ['bar'])
+        self.assertEqual(webob_req.POST.getall('foo'), ['bar'])
 
 
 class TestDjangoWebobResponse(TestCase):
@@ -61,31 +61,31 @@ class TestDjangoWebobResponse(TestCase):
         return webob_to_django_response(Response(*args, **kwargs))
 
     def test_status_code(self):
-        self.assertEquals(self._as_django(status=200).status_code, 200)
-        self.assertEquals(self._as_django(status=404).status_code, 404)
-        self.assertEquals(self._as_django(status=500).status_code, 500)
+        self.assertEqual(self._as_django(status=200).status_code, 200)
+        self.assertEqual(self._as_django(status=404).status_code, 404)
+        self.assertEqual(self._as_django(status=500).status_code, 500)
 
     def test_content(self):
-        self.assertEquals(self._as_django(body=u"foo").content, "foo")
-        self.assertEquals(self._as_django(app_iter=(c for c in u"foo")).content, "foo")
-        self.assertEquals(self._as_django(body="foo", charset="utf-8").content, "foo")
+        self.assertEqual(self._as_django(body=u"foo").content, b"foo")
+        self.assertEqual(self._as_django(app_iter=(c for c in u"foo")).content, b"foo")
+        self.assertEqual(self._as_django(body=b"foo", charset="utf-8").content, b"foo")
 
         encoded_snowman = u"\N{SNOWMAN}".encode('utf-8')
-        self.assertEquals(self._as_django(body=encoded_snowman, charset="utf-8").content, encoded_snowman)
+        self.assertEqual(self._as_django(body=encoded_snowman, charset="utf-8").content, encoded_snowman)
 
     def test_headers(self):
         self.assertIn('X-Foo', self._as_django(headerlist=[('X-Foo', 'bar')]))
-        self.assertEquals(self._as_django(headerlist=[('X-Foo', 'bar')])['X-Foo'], 'bar')
+        self.assertEqual(self._as_django(headerlist=[('X-Foo', 'bar')])['X-Foo'], 'bar')
 
     def test_content_types(self):
         # JSON content type (no charset should be returned)
-        self.assertEquals(
+        self.assertEqual(
             self._as_django(content_type='application/json')['Content-Type'],
             'application/json'
         )
 
         # HTML content type (UTF-8 charset should be returned)
-        self.assertEquals(
+        self.assertEqual(
             self._as_django(content_type='text/html')['Content-Type'],
             'text/html; charset=UTF-8'
         )

--- a/xblock/test/settings.py
+++ b/xblock/test/settings.py
@@ -1,4 +1,5 @@
 """Django settings for toy runtime project."""
+from __future__ import unicode_literals
 import os
 
 DEBUG = True

--- a/xblock/test/test_asides.py
+++ b/xblock/test/test_asides.py
@@ -1,6 +1,7 @@
 """
 Test XBlock Aside
 """
+from builtins import zip
 from unittest import TestCase
 from xblock.core import XBlockAside, XBlock
 from xblock.fields import ScopeIds, Scope, String
@@ -130,7 +131,7 @@ class ParsingTest(AsideRuntimeSetup, XmlTestMixin):
         """
         self.assertEqual(first.scope_ids.block_type, second.scope_ids.block_type)
         self.assertEqual(first.fields, second.fields)
-        for field in first.fields.itervalues():
+        for field in list(first.fields.values()):
             self.assertEqual(field.read_from(first), field.read_from(second), field)
 
     def _test_roundrip_of(self, block):
@@ -139,7 +140,7 @@ class ParsingTest(AsideRuntimeSetup, XmlTestMixin):
         """
         restored = self.parse_xml_to_block(self.export_xml_for_block(block))
         self._assert_xthing_equal(block, restored)
-        for first, second in itertools.izip(self.runtime.get_asides(block), self.runtime.get_asides(restored)):
+        for first, second in zip(self.runtime.get_asides(block), self.runtime.get_asides(restored)):
             self._assert_xthing_equal(first, second)
 
     @XBlockAside.register_temp_plugin(TestAside, 'test_aside')

--- a/xblock/test/test_asides.py
+++ b/xblock/test/test_asides.py
@@ -2,6 +2,8 @@
 Test XBlock Aside
 """
 from builtins import zip
+import future.utils
+
 from unittest import TestCase
 from xblock.core import XBlockAside, XBlock
 from xblock.fields import ScopeIds, Scope, String
@@ -131,7 +133,7 @@ class ParsingTest(AsideRuntimeSetup, XmlTestMixin):
         """
         self.assertEqual(first.scope_ids.block_type, second.scope_ids.block_type)
         self.assertEqual(first.fields, second.fields)
-        for field in list(first.fields.values()):
+        for field in future.utils.itervalues(first.fields):
             self.assertEqual(field.read_from(first), field.read_from(second), field)
 
     def _test_roundrip_of(self, block):

--- a/xblock/test/test_asides.py
+++ b/xblock/test/test_asides.py
@@ -1,6 +1,7 @@
 """
 Test XBlock Aside
 """
+from __future__ import unicode_literals
 from builtins import zip
 import future.utils
 

--- a/xblock/test/test_asides.py
+++ b/xblock/test/test_asides.py
@@ -2,10 +2,10 @@
 Test XBlock Aside
 """
 from __future__ import unicode_literals
-from builtins import zip
-import future.utils
-
+from builtins import zip  # pylint: disable=redefined-builtin
 from unittest import TestCase
+
+import future.utils
 from xblock.core import XBlockAside, XBlock
 from xblock.fields import ScopeIds, Scope, String
 from xblock.fragment import Fragment
@@ -13,7 +13,6 @@ from xblock.runtime import DictKeyValueStore, KvsFieldData
 from xblock.test.test_runtime import TestXBlock
 from xblock.test.tools import TestRuntime
 from xblock.test.test_parsing import Leaf, XmlTestMixin
-from timeit import itertools
 
 
 class TestAside(XBlockAside):

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -588,7 +588,7 @@ def test_xblock_save_one():
     def fake_set_many(block, update_dict):  # pylint: disable=unused-argument
         """Mock update method that throws a KeyValueMultiSaveError indicating
            that only one field was correctly saved."""
-        raise KeyValueMultiSaveError([update_dict.keys()[0]])
+        raise KeyValueMultiSaveError([list(update_dict.keys())[0]])
 
     field_tester = setup_save_failure(fake_set_many)
 
@@ -918,7 +918,7 @@ def test_json_handler_return_unicode():
 
     response = test_func(Mock(), test_request, "dummy_suffix")
     for request_part in response.request:
-        assert_equals(type(request_part), unicode)
+        assert_equals(type(request_part), str)
 
 
 @ddt.ddt

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -3,6 +3,7 @@
 Tests the fundamentals of XBlocks including - but not limited to -
 metaclassing, field access, caching, serialization, and bulk saves.
 """
+from __future__ import unicode_literals
 
 from builtins import str
 

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -4,19 +4,17 @@ Tests the fundamentals of XBlocks including - but not limited to -
 metaclassing, field access, caching, serialization, and bulk saves.
 """
 from __future__ import unicode_literals
-from builtins import next
-
-from builtins import str
+from builtins import next, str  # pylint: disable=redefined-builtin
 
 # Allow accessing protected members for testing purposes
 # pylint: disable=W0212
-from mock import patch, MagicMock, Mock
 from datetime import datetime
 import json
 import re
 import unittest
 
 import ddt
+from mock import patch, MagicMock, Mock
 from webob import Response
 
 from xblock.core import XBlock

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -4,6 +4,8 @@ Tests the fundamentals of XBlocks including - but not limited to -
 metaclassing, field access, caching, serialization, and bulk saves.
 """
 
+from builtins import str
+
 # Allow accessing protected members for testing purposes
 # pylint: disable=W0212
 from mock import patch, MagicMock, Mock
@@ -29,9 +31,14 @@ from xblock.mixins import ScopedStorageMixin
 from xblock.runtime import Runtime
 
 from xblock.test.tools import (
-    assert_equals, assert_raises, assert_raises_regexp,
-    assert_not_equals, assert_false,
-    WarningTestMixin, TestRuntime,
+    assert_equals,
+    assert_false,
+    assert_is_instance,
+    assert_not_equals,
+    assert_raises,
+    assert_raises_regexp,
+    WarningTestMixin,
+    TestRuntime,
 )
 
 
@@ -588,7 +595,7 @@ def test_xblock_save_one():
     def fake_set_many(block, update_dict):  # pylint: disable=unused-argument
         """Mock update method that throws a KeyValueMultiSaveError indicating
            that only one field was correctly saved."""
-        raise KeyValueMultiSaveError([list(update_dict.keys())[0]])
+        raise KeyValueMultiSaveError([next(iter(update_dict))])
 
     field_tester = setup_save_failure(fake_set_many)
 
@@ -821,10 +828,10 @@ def test_cached_parent():
 
 def test_json_handler_basic():
     test_self = Mock()
-    test_data = {"foo": "bar", "baz": "quux"}
+    test_data = {u"foo": u"bar", u"baz": u"quux"}
     test_data_json = json.dumps(test_data)
-    test_suffix = "suff"
-    test_request = Mock(method="POST", body=test_data_json)
+    test_suffix = u"suff"
+    test_request = Mock(method=u"POST", body=test_data_json)
 
     @XBlock.json_handler
     def test_func(self, request, suffix):
@@ -835,7 +842,7 @@ def test_json_handler_basic():
 
     response = test_func(test_self, test_request, test_suffix)
     assert_equals(response.status_code, 200)
-    assert_equals(response.body, test_data_json)
+    assert_equals(response.body.decode('utf-8'), test_data_json)
     assert_equals(response.content_type, "application/json")
 
 
@@ -849,7 +856,7 @@ def test_json_handler_invalid_json():
     response = test_func(Mock(), test_request, "dummy_suffix")
     # pylint: disable=no-member
     assert_equals(response.status_code, 400)
-    assert_equals(json.loads(response.body), {"error": "Invalid JSON"})
+    assert_equals(json.loads(response.body.decode('utf-8')), {"error": "Invalid JSON"})
     assert_equals(response.content_type, "application/json")
 
 
@@ -863,7 +870,7 @@ def test_json_handler_get():
     response = test_func(Mock(), test_request, "dummy_suffix")
     # pylint: disable=no-member
     assert_equals(response.status_code, 405)
-    assert_equals(json.loads(response.body), {"error": "Method must be POST"})
+    assert_equals(json.loads(response.body.decode('utf-8')), {"error": "Method must be POST"})
     assert_equals(list(response.allow), ["POST"])
 
 
@@ -877,23 +884,23 @@ def test_json_handler_empty_request():
     response = test_func(Mock(), test_request, "dummy_suffix")
     # pylint: disable=no-member
     assert_equals(response.status_code, 400)
-    assert_equals(json.loads(response.body), {"error": "Invalid JSON"})
+    assert_equals(json.loads(response.body.decode('utf-8')), {"error": "Invalid JSON"})
     assert_equals(response.content_type, "application/json")
 
 
 def test_json_handler_error():
     test_status_code = 418
-    test_message = "I'm a teapot"
-    test_request = Mock(method="POST", body="{}")
+    test_message = u"I'm a teapot"
+    test_request = Mock(method=u"POST", body="{}")
 
     @XBlock.json_handler
     def test_func(self, request, suffix):   # pylint: disable=unused-argument
         raise JsonHandlerError(test_status_code, test_message)
 
-    response = test_func(Mock(), test_request, "dummy_suffix")  # pylint: disable=assignment-from-no-return
+    response = test_func(Mock(), test_request, u"dummy_suffix")  # pylint: disable=assignment-from-no-return
     assert_equals(response.status_code, test_status_code)
-    assert_equals(json.loads(response.body), {"error": test_message})
-    assert_equals(response.content_type, "application/json")
+    assert_equals(json.loads(response.body.decode('utf-8')), {u"error": test_message})
+    assert_equals(response.content_type, u"application/json")
 
 
 def test_json_handler_return_response():
@@ -901,12 +908,12 @@ def test_json_handler_return_response():
 
     @XBlock.json_handler
     def test_func(self, request, suffix):  # pylint: disable=unused-argument
-        return Response(body="not JSON", status=418, content_type="text/plain")
+        return Response(body=u"not JSON", status=418, content_type=u"text/plain")
 
-    response = test_func(Mock(), test_request, "dummy_suffix")
-    assert_equals(response.body, "not JSON")
+    response = test_func(Mock(), test_request, u"dummy_suffix")
+    assert_equals(response.ubody, u"not JSON")
     assert_equals(response.status_code, 418)
-    assert_equals(response.content_type, "text/plain")
+    assert_equals(response.content_type, u"text/plain")
 
 
 def test_json_handler_return_unicode():
@@ -939,48 +946,78 @@ class OpenLocalResourceTest(unittest.TestCase):
         return "!" + name + "!"
 
     @ddt.data(
-        "public/hey.js",
-        "public/sub/hey.js",
-        "public/js/vendor/jNotify.jQuery.min.js",
-        "public/something.foo",         # Unknown file extension is fine
-        "public/a/long/PATH/no-problem=here$123.ext",
-        "public/ℓιвяαяу.js",
+        u"public/hey.js",
+        u"public/sub/hey.js",
+        u"public/js/vendor/jNotify.jQuery.min.js",
+        u"public/something.foo",         # Unknown file extension is fine
+        u"public/a/long/PATH/no-problem=here$123.ext",
+        u"public/ℓιвяαяу.js",
     )
     def test_open_good_local_resource(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=None)
         with patch('pkg_resources.resource_stream', self.stub_resource_stream):
             assert loadable.open_local_resource(uri) == "!" + uri + "!"
+            assert loadable.open_local_resource(uri.encode('utf-8')) == "!" + uri + "!"
 
     @ddt.data(
-        "public/../secret.js",
-        "public/.git/secret.js",
-        "static/secret.js",
-        "../public/no-no.bad",
-        "image.png",
-        ".git/secret.js",
-        "static/ℓιвяαяу.js",
+        u"public/hey.js".encode('utf-8'),
+        u"public/sub/hey.js".encode('utf-8'),
+        u"public/js/vendor/jNotify.jQuery.min.js".encode('utf-8'),
+        u"public/something.foo".encode('utf-8'),         # Unknown file extension is fine
+        u"public/a/long/PATH/no-problem=here$123.ext".encode('utf-8'),
+        u"public/ℓιвяαяу.js".encode('utf-8'),
+    )
+    def test_open_good_local_resource_binary(self, uri):
+        loadable = self.LoadableXBlock(None, scope_ids=None)
+        with patch('pkg_resources.resource_stream', self.stub_resource_stream):
+            assert loadable.open_local_resource(uri) == "!" + uri.decode('utf-8') + "!"
+
+    @ddt.data(
+        u"public/../secret.js",
+        u"public/.git/secret.js",
+        u"static/secret.js",
+        u"../public/no-no.bad",
+        u"image.png",
+        u".git/secret.js",
+        u"static/ℓιвяαяу.js",
     )
     def test_open_bad_local_resource(self, uri):
         loadable = self.LoadableXBlock(None, scope_ids=None)
         with patch('pkg_resources.resource_stream', self.stub_resource_stream):
-            msg = ".*: %s" % re.escape(repr(uri))
+            msg_pattern = ".*: %s" % re.escape(repr(uri))
+            with assert_raises_regexp(DisallowedFileError, msg_pattern):
+                loadable.open_local_resource(uri)
+
+    @ddt.data(
+        u"public/../secret.js".encode('utf-8'),
+        u"public/.git/secret.js".encode('utf-8'),
+        u"static/secret.js".encode('utf-8'),
+        u"../public/no-no.bad".encode('utf-8'),
+        u"image.png".encode('utf-8'),
+        u".git/secret.js".encode('utf-8'),
+        u"static/ℓιвяαяу.js".encode('utf-8'),
+    )
+    def test_open_bad_local_resource_binary(self, uri):
+        loadable = self.LoadableXBlock(None, scope_ids=None)
+        with patch('pkg_resources.resource_stream', self.stub_resource_stream):
+            msg = u".*: %s" % re.escape(repr(uri.decode('utf-8')))
             with assert_raises_regexp(DisallowedFileError, msg):
                 loadable.open_local_resource(uri)
 
     @ddt.data(
-        "public/hey.js",
-        "public/sub/hey.js",
-        "public/js/vendor/jNotify.jQuery.min.js",
-        "public/something.foo",         # Unknown file extension is fine
-        "public/a/long/PATH/no-problem=here$123.ext",
-        "public/ℓιвяαяу.js",
-        "public/foo.js",
-        "public/.git/secret.js",
-        "static/secret.js",
-        "../public/no-no.bad",
-        "image.png",
-        ".git/secret.js",
-        "static/ℓιвяαяу.js",
+        u"public/hey.js",
+        u"public/sub/hey.js",
+        u"public/js/vendor/jNotify.jQuery.min.js",
+        u"public/something.foo",         # Unknown file extension is fine
+        u"public/a/long/PATH/no-problem=here$123.ext",
+        u"public/ℓιвяαяу.js",
+        u"public/foo.js",
+        u"public/.git/secret.js",
+        u"static/secret.js",
+        u"../public/no-no.bad",
+        u"image.png",
+        u".git/secret.js",
+        u"static/ℓιвяαяу.js",
     )
     def test_open_local_resource_with_no_resources_dir(self, uri):
         unloadable = self.UnloadableXBlock(None, scope_ids=None)

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -918,7 +918,7 @@ def test_json_handler_return_unicode():
 
     response = test_func(Mock(), test_request, "dummy_suffix")
     for request_part in response.request:
-        assert_equals(type(request_part), str)
+        assert_is_instance(request_part, str)
 
 
 @ddt.ddt

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -4,6 +4,7 @@ Tests the fundamentals of XBlocks including - but not limited to -
 metaclassing, field access, caching, serialization, and bulk saves.
 """
 from __future__ import unicode_literals
+from builtins import next
 
 from builtins import str
 

--- a/xblock/test/test_field_data.py
+++ b/xblock/test/test_field_data.py
@@ -2,7 +2,7 @@
 Tests of the utility FieldData's defined by xblock
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 
 from mock import Mock
 

--- a/xblock/test/test_field_data.py
+++ b/xblock/test/test_field_data.py
@@ -1,6 +1,7 @@
 """
 Tests of the utility FieldData's defined by xblock
 """
+from builtins import object
 
 from mock import Mock
 

--- a/xblock/test/test_field_data.py
+++ b/xblock/test/test_field_data.py
@@ -1,6 +1,7 @@
 """
 Tests of the utility FieldData's defined by xblock
 """
+from __future__ import unicode_literals
 from builtins import object
 
 from mock import Mock

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -10,13 +10,13 @@ from contextlib import contextmanager
 import datetime as dt
 import itertools
 import math
-from mock import Mock
-import pytz
 import textwrap
 import unittest
 import warnings
 
 import ddt
+from mock import Mock
+import pytz
 
 from xblock.core import XBlock, Scope
 from xblock.field_data import DictFieldData

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -64,7 +64,7 @@ class FieldTest(unittest.TestCase):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always", DeprecationWarning)
             yield
-        self.assertEquals(count, sum(
+        self.assertEqual(count, sum(
             1 for warning in caught
             if issubclass(warning.category, DeprecationWarning)
         ))
@@ -671,16 +671,16 @@ class SentinelTest(unittest.TestCase):
     """
     def test_equality(self):
         base = Sentinel('base')
-        self.assertEquals(base, base)
-        self.assertEquals(base, Sentinel('base'))
+        self.assertEqual(base, base)
+        self.assertEqual(base, Sentinel('base'))
         self.assertNotEquals(base, Sentinel('foo'))
         self.assertNotEquals(base, 'base')
 
     def test_hashing(self):
         base = Sentinel('base')
         a_dict = {base: True}
-        self.assertEquals(a_dict[Sentinel('base')], True)
-        self.assertEquals(a_dict[base], True)
+        self.assertEqual(a_dict[Sentinel('base')], True)
+        self.assertEqual(a_dict[base], True)
         self.assertNotIn(Sentinel('foo'), a_dict)
         self.assertNotIn('base', a_dict)
 
@@ -695,14 +695,14 @@ class FieldSerializationTest(unittest.TestCase):
         Helper method: checks if _type's to_string given instance of _type returns expected string
         """
         result = _type().to_string(value)
-        self.assertEquals(result, string)
+        self.assertEqual(result, string)
 
     def assert_from_string(self, _type, string, value):
         """
         Helper method: checks if _type's from_string given string representation of type returns expected value
         """
         result = _type().from_string(string)
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     # Serialisation test data that is tested both ways, i.e. whether serialisation of the value
     # yields the string and deserialisation of the string yields the value.

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -6,16 +6,15 @@ from __future__ import unicode_literals
 # Allow accessing protected members for testing purposes
 # pylint: disable=W0212
 
-from mock import Mock
-import unittest
-
-import datetime as dt
-import pytz
-import warnings
-import math
-import textwrap
-import itertools
 from contextlib import contextmanager
+import datetime as dt
+import itertools
+import math
+from mock import Mock
+import pytz
+import textwrap
+import unittest
+import warnings
 
 import ddt
 

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -674,8 +674,8 @@ class SentinelTest(unittest.TestCase):
         base = Sentinel('base')
         self.assertEqual(base, base)
         self.assertEqual(base, Sentinel('base'))
-        self.assertNotEquals(base, Sentinel('foo'))
-        self.assertNotEquals(base, 'base')
+        self.assertNotEqual(base, Sentinel('foo'))
+        self.assertNotEqual(base, 'base')
 
     def test_hashing(self):
         base = Sentinel('base')

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -1,6 +1,7 @@
 """
 Tests for classes extending Field.
 """
+from __future__ import unicode_literals
 
 # Allow accessing protected members for testing purposes
 # pylint: disable=W0212

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -863,5 +863,5 @@ class FieldSerializationTest(unittest.TestCase):
         ['{"foo":"bar"}', '[1, 2, 3]', 'baz', '1.abc', 'defg']))
     def test_from_string_errors(self, _type, string):
         """ Cases that raises various exceptions."""
-        with self.assertRaises(StandardError):
+        with self.assertRaises(Exception):
             _type().from_string(string)

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -23,6 +23,9 @@ covered, we define sets of test properties (which actually implement the
 tests of the various operations), and test setup (which set up the
 particular combination of initial conditions that we want to test)
 """
+from builtins import next
+from builtins import range
+from builtins import object
 
 import copy
 from mock import Mock, patch
@@ -466,7 +469,7 @@ class TestImmutableWithComputedDefault(ImmutableTestCases, ComputedDefaultTestCa
 
     @property
     def default_iterator(self):
-        return iter(xrange(1000))
+        return iter(list(range(1000)))
 
 
 class TestMutableWithStaticDefault(MutableTestCases, StaticDefaultTestCases, DefaultValueMutationProperties):
@@ -483,7 +486,7 @@ class TestMutableWithComputedDefault(MutableTestCases, ComputedDefaultTestCases,
 
     @property
     def default_iterator(self):
-        return ([None] * i for i in xrange(1000))
+        return ([None] * i for i in range(1000))
 
 
 class TestImmutableWithInitialValue(ImmutableTestCases, InitialValueProperties):

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -23,6 +23,7 @@ covered, we define sets of test properties (which actually implement the
 tests of the various operations), and test setup (which set up the
 particular combination of initial conditions that we want to test)
 """
+from __future__ import unicode_literals
 from builtins import next
 from builtins import range
 from builtins import object

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -440,7 +440,7 @@ class MutableTestCases(UniversalTestCases, MutationProperties):
     """Set up tests of a mutable field"""
     field_class = List
     field_default = []
-    new_value = ['a', 'b']
+    new_value = [u'a', u'b']
 
     def mutate(self, value):
         """Modify the supplied value"""
@@ -451,7 +451,7 @@ class UniqueIdTestCases(ImmutableTestCases):
     """Set up tests for field with UNIQUE_ID default"""
     field_class = String
     field_default = UNIQUE_ID
-    new_value = 'user-assigned ID'
+    new_value = u'user-assigned ID'
 # pylint: enable=no-member
 
 
@@ -469,7 +469,7 @@ class TestImmutableWithComputedDefault(ImmutableTestCases, ComputedDefaultTestCa
 
     @property
     def default_iterator(self):
-        return iter(list(range(1000)))
+        return iter(range(1000))
 
 
 class TestMutableWithStaticDefault(MutableTestCases, StaticDefaultTestCases, DefaultValueMutationProperties):

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -24,9 +24,7 @@ tests of the various operations), and test setup (which set up the
 particular combination of initial conditions that we want to test)
 """
 from __future__ import unicode_literals
-from builtins import next
-from builtins import range
-from builtins import object
+from builtins import next, range, object  # pylint: disable=redefined-builtin
 
 import copy
 from mock import Mock, patch

--- a/xblock/test/test_internal.py
+++ b/xblock/test/test_internal.py
@@ -69,20 +69,20 @@ class TestNamedDescriptorsMetaclass(TestCase):
     "Tests of the NamedDescriptorsMetaclass."
 
     def test_named_descriptor(self):
-        self.assertEquals('test_descriptor', NamingTester.test_descriptor.__name__)
+        self.assertEqual('test_descriptor', NamingTester.test_descriptor.__name__)
 
     def test_named_getset_descriptor(self):
-        self.assertEquals('test_getset_descriptor', NamingTester.test_getset_descriptor.__name__)
+        self.assertEqual('test_getset_descriptor', NamingTester.test_getset_descriptor.__name__)
 
     def test_inherited_naming(self):
-        self.assertEquals('test_descriptor', InheritedNamingTester.test_descriptor.__name__)
-        self.assertEquals('inherited', InheritedNamingTester.inherited.__name__)
+        self.assertEqual('test_descriptor', InheritedNamingTester.test_descriptor.__name__)
+        self.assertEqual('inherited', InheritedNamingTester.inherited.__name__)
 
     def test_unnamed_attribute(self):
         self.assertFalse(hasattr(NamingTester.test_nonnameable, '__name__'))
 
     def test_method(self):
-        self.assertEquals('meth', NamingTester.meth.__name__)
+        self.assertEqual('meth', NamingTester.meth.__name__)
 
     def test_prop(self):
         self.assertFalse(hasattr(NamingTester.prop, '__name__'))

--- a/xblock/test/test_internal.py
+++ b/xblock/test/test_internal.py
@@ -1,6 +1,6 @@
 """Tests of the xblock.internal module."""
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 
 from unittest import TestCase
 

--- a/xblock/test/test_internal.py
+++ b/xblock/test/test_internal.py
@@ -1,8 +1,10 @@
 """Tests of the xblock.internal module."""
+from builtins import object
 
 from unittest import TestCase
 
 from xblock.internal import class_lazy, NamedAttributesMetaclass, Nameable
+from future.utils import with_metaclass
 
 
 class TestLazyClassProperty(TestCase):
@@ -41,9 +43,8 @@ class TestGetSetDescriptor(Nameable):
         pass
 
 
-class NamingTester(object):
+class NamingTester(with_metaclass(NamedAttributesMetaclass, object)):
     """Class with several descriptors that should get names."""
-    __metaclass__ = NamedAttributesMetaclass
 
     test_descriptor = TestDescriptor()
     test_getset_descriptor = TestGetSetDescriptor()

--- a/xblock/test/test_internal.py
+++ b/xblock/test/test_internal.py
@@ -1,4 +1,5 @@
 """Tests of the xblock.internal module."""
+from __future__ import unicode_literals
 from builtins import object
 
 from unittest import TestCase

--- a/xblock/test/test_json_conversion.py
+++ b/xblock/test/test_json_conversion.py
@@ -2,6 +2,7 @@
 Tests asserting that ModelTypes convert to and from json when working
 with ModelDatas
 """
+from builtins import object
 # Allow inspection of private class members
 # pylint: disable=W0212
 from mock import Mock

--- a/xblock/test/test_json_conversion.py
+++ b/xblock/test/test_json_conversion.py
@@ -3,7 +3,7 @@ Tests asserting that ModelTypes convert to and from json when working
 with ModelDatas
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 # Allow inspection of private class members
 # pylint: disable=W0212
 from mock import Mock

--- a/xblock/test/test_json_conversion.py
+++ b/xblock/test/test_json_conversion.py
@@ -2,6 +2,7 @@
 Tests asserting that ModelTypes convert to and from json when working
 with ModelDatas
 """
+from __future__ import unicode_literals
 from builtins import object
 # Allow inspection of private class members
 # pylint: disable=W0212

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -1,6 +1,7 @@
 """
 Tests of the XBlock-family functionality mixins
 """
+from __future__ import unicode_literals
 from builtins import object
 import future.utils
 

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -188,7 +188,7 @@ class TestViewsMixin(TestCase):
                 ("multi_featured_view", "functionality2", True),
                 ("multi_featured_view", "bogus_functionality", False),
         ):
-            self.assertEquals(
+            self.assertEqual(
                 test_xblock.has_support(getattr(test_xblock, view_name), functionality),
                 expected_result
             )
@@ -213,7 +213,7 @@ class TestViewsMixin(TestCase):
                 ("functionality_supported_view", "a_functionality", True),
                 ("functionality_supported_view", "bogus_functionality", False),
         ):
-            self.assertEquals(
+            self.assertEqual(
                 test_xblock.has_support(getattr(test_xblock, view_name, None), functionality),
                 expected_result
             )

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -2,6 +2,8 @@
 Tests of the XBlock-family functionality mixins
 """
 from builtins import object
+import future.utils
+
 import ddt as ddt
 from datetime import datetime
 import pytz
@@ -270,13 +272,13 @@ class TestXmlSerializationMixin(TestCase):
 
     def _assert_node_attributes(self, node, expected_attributes, entry_point=None):
         """ Checks XML node attributes to match expected_attributes"""
-        node_attributes = list(node.keys())
+        node_attributes = node.keys()
         node_attributes.remove('xblock-family')
 
         self.assertEqual(node.get('xblock-family'), entry_point if entry_point else self.TestXBlock.entry_point)
         self.assertEqual(set(node_attributes), set(expected_attributes.keys()))
 
-        for key, value in list(expected_attributes.items()):
+        for key, value in future.utils.iteritems(expected_attributes):
             if value != UNIQUE_ID:
                 self.assertEqual(node.get(key), value)
             else:
@@ -300,7 +302,7 @@ class TestXmlSerializationMixin(TestCase):
         node = etree.Element(self.test_xblock_tag)
 
         # Precondition check: no fields are set.
-        for field_name in list(self.test_xblock.fields.keys()):
+        for field_name in future.utils.iterkeys(self.test_xblock.fields):
             self.assertFalse(self.test_xblock.fields[field_name].is_set_on(self.test_xblock))
 
         self.test_xblock.add_xml_to_node(node)

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -2,7 +2,7 @@
 Tests of the XBlock-family functionality mixins
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 import future.utils
 
 import ddt as ddt

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -3,15 +3,15 @@ Tests of the XBlock-family functionality mixins
 """
 from __future__ import unicode_literals
 from builtins import object  # pylint: disable=redefined-builtin
-import future.utils
 
-import ddt as ddt
 from datetime import datetime
-import pytz
-from lxml import etree
-import mock
 from unittest import TestCase
 
+import ddt as ddt
+import future.utils
+from lxml import etree
+import mock
+import pytz
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import List, Scope, Integer, String, ScopeIds, UNIQUE_ID, DateTime
 from xblock.field_data import DictFieldData

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -1,6 +1,7 @@
 """
 Tests of the XBlock-family functionality mixins
 """
+from builtins import object
 import ddt as ddt
 from datetime import datetime
 import pytz
@@ -269,13 +270,13 @@ class TestXmlSerializationMixin(TestCase):
 
     def _assert_node_attributes(self, node, expected_attributes, entry_point=None):
         """ Checks XML node attributes to match expected_attributes"""
-        node_attributes = node.keys()
+        node_attributes = list(node.keys())
         node_attributes.remove('xblock-family')
 
         self.assertEqual(node.get('xblock-family'), entry_point if entry_point else self.TestXBlock.entry_point)
         self.assertEqual(set(node_attributes), set(expected_attributes.keys()))
 
-        for key, value in expected_attributes.iteritems():
+        for key, value in list(expected_attributes.items()):
             if value != UNIQUE_ID:
                 self.assertEqual(node.get(key), value)
             else:
@@ -299,7 +300,7 @@ class TestXmlSerializationMixin(TestCase):
         node = etree.Element(self.test_xblock_tag)
 
         # Precondition check: no fields are set.
-        for field_name in self.test_xblock.fields.keys():
+        for field_name in list(self.test_xblock.fields.keys()):
             self.assertFalse(self.test_xblock.fields[field_name].is_set_on(self.test_xblock))
 
         self.test_xblock.add_xml_to_node(node)

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -2,15 +2,16 @@
 """Test XML parsing in XBlocks."""
 from __future__ import unicode_literals
 from builtins import str, object  # pylint: disable=redefined-builtin
-import future.utils
 
 import re
 import io
 import textwrap
 import unittest
+
+import future.utils
 import ddt
-import mock
 from lxml import etree
+import mock
 
 from xblock.core import XBlock, XML_NAMESPACES
 from xblock.fields import Scope, String, Integer, Dict, List

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test XML parsing in XBlocks."""
+from __future__ import unicode_literals
 from builtins import str
 from builtins import object
 import future.utils

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -269,8 +269,8 @@ class ExportTest(XmlTest, unittest.TestCase):
                 sequence='["one", "two", "three"]' />
             """))
 
-        self.assertEquals(block.dictionary, {"foo": "bar"})
-        self.assertEquals(block.sequence, ["one", "two", "three"])
+        self.assertEqual(block.dictionary, {"foo": "bar"})
+        self.assertEqual(block.sequence, ["one", "two", "three"])
 
     @XBlock.register_temp_plugin(LeafWithOption)
     def test_export_then_import_with_options(self):

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Test XML parsing in XBlocks."""
 from __future__ import unicode_literals
-from builtins import str
-from builtins import object
+from builtins import str, object  # pylint: disable=redefined-builtin
 import future.utils
 
 import re

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 """Test XML parsing in XBlocks."""
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 
 import re
-import StringIO
+import io
 import textwrap
 import unittest
 import ddt
@@ -19,7 +23,7 @@ from xblock.test.toy_runtime import ToyRuntime
 
 def get_namespace_attrs():
     """ Returns string suitable to be used as an xmlns parameters in XBlock XML representation """
-    return " ".join('xmlns:{}="{}"'.format(k, v) for k, v in XML_NAMESPACES.items())
+    return " ".join('xmlns:{}="{}"'.format(k, v) for k, v in list(XML_NAMESPACES.items()))
 
 
 class Leaf(XBlock):
@@ -104,7 +108,7 @@ class XmlTestMixin(object):
 
     def export_xml_for_block(self, block):
         """A helper to return the XML string for a block."""
-        output = StringIO.StringIO()
+        output = io.StringIO()
         self.runtime.export_to_xml(block, output)
         return output.getvalue()
 
@@ -404,7 +408,7 @@ class TestRoundTrip(XmlTest, unittest.TestCase):
 
         self.assertEqual(parsed.sequence, expected_seq)
         self.assertNotEqual(parsed.dictionary, expected_dict)
-        self.assertEqual(parsed.dictionary, {str(key): value for key, value in expected_dict.items()})
+        self.assertEqual(parsed.dictionary, {str(key): value for key, value in list(expected_dict.items())})
 
     @XBlock.register_temp_plugin(LeafWithDictAndList)
     def test_none_contents_roundtrip(self):

--- a/xblock/test/test_parsing.py
+++ b/xblock/test/test_parsing.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Test XML parsing in XBlocks."""
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import object
+import future.utils
 
 import re
 import io
@@ -23,7 +22,7 @@ from xblock.test.toy_runtime import ToyRuntime
 
 def get_namespace_attrs():
     """ Returns string suitable to be used as an xmlns parameters in XBlock XML representation """
-    return " ".join('xmlns:{}="{}"'.format(k, v) for k, v in list(XML_NAMESPACES.items()))
+    return " ".join('xmlns:{}="{}"'.format(k, v) for k, v in future.utils.iteritems(XML_NAMESPACES))
 
 
 class Leaf(XBlock):
@@ -79,9 +78,9 @@ class CustomXml(XBlock):
             if child.tag is not etree.Comment:
                 block.runtime.add_node_as_child(block, child, id_generator)
         # Now build self.inner_xml from the XML of node's children
-        # We can't just call tostring() on each child because it adds xmlns: attributes
-        xml_str = etree.tostring(node)
-        block.inner_xml = xml_str[xml_str.index('>') + 1:xml_str.rindex('<')]
+        # We can't just call tounicode() on each child because it adds xmlns: attributes
+        xml_str = etree.tounicode(node)
+        block.inner_xml = xml_str[xml_str.index(u'>') + 1:xml_str.rindex(u'<')]
         return block
 
     def add_xml_to_node(self, node):
@@ -108,12 +107,12 @@ class XmlTestMixin(object):
 
     def export_xml_for_block(self, block):
         """A helper to return the XML string for a block."""
-        output = io.StringIO()
+        output = io.BytesIO()
         self.runtime.export_to_xml(block, output)
         return output.getvalue()
 
 
-class XmlTest(XmlTestMixin):
+class XmlTest(XmlTestMixin, unittest.TestCase):
     """Helpful things for XML tests."""
     def setUp(self):
         super(XmlTest, self).setUp()
@@ -127,24 +126,24 @@ class ParsingTest(XmlTest, unittest.TestCase):
 
     @XBlock.register_temp_plugin(Leaf)
     def test_parsing(self):
-        block = self.parse_xml_to_block("<leaf data2='parsed'/>")
+        block = self.parse_xml_to_block(u"<leaf data2='parsed'/>")
 
         self.assertIsInstance(block, Leaf)
-        self.assertEqual(block.data1, "default_value")
-        self.assertEqual(block.data2, "parsed")
-        self.assertEqual(block.content, "")
+        self.assertEqual(block.data1, u"default_value")
+        self.assertEqual(block.data2, u"parsed")
+        self.assertEqual(block.content, u"")
 
     @XBlock.register_temp_plugin(Leaf)
     def test_parsing_content(self):
-        block = self.parse_xml_to_block("<leaf>my text!</leaf>")
+        block = self.parse_xml_to_block(u"<leaf>my text!</leaf>")
 
         self.assertIsInstance(block, Leaf)
-        self.assertEqual(block.content, "my text!")
+        self.assertEqual(block.content, u"my text!")
 
     @XBlock.register_temp_plugin(Leaf)
     @XBlock.register_temp_plugin(Container)
     def test_parsing_children(self):
-        block = self.parse_xml_to_block("""\
+        block = self.parse_xml_to_block(u"""\
                     <container>
                         <leaf data1='child1'/>
                         <leaf data1='child2'/>
@@ -155,18 +154,18 @@ class ParsingTest(XmlTest, unittest.TestCase):
 
         child1 = self.runtime.get_block(block.children[0])
         self.assertIsInstance(child1, Leaf)
-        self.assertEqual(child1.data1, "child1")
+        self.assertEqual(child1.data1, u"child1")
         self.assertEqual(child1.parent, block.scope_ids.usage_id)
 
         child2 = self.runtime.get_block(block.children[1])
         self.assertIsInstance(child2, Leaf)
-        self.assertEqual(child2.data1, "child2")
+        self.assertEqual(child2.data1, u"child2")
         self.assertEqual(child2.parent, block.scope_ids.usage_id)
 
     @XBlock.register_temp_plugin(Leaf)
     @XBlock.register_temp_plugin(Container)
     def test_xml_with_comments(self):
-        block = self.parse_xml_to_block("""\
+        block = self.parse_xml_to_block(u"""\
                     <!-- This is a comment -->
                     <container>
                         <leaf data1='child1'/>
@@ -183,7 +182,7 @@ class ParsingTest(XmlTest, unittest.TestCase):
         """
         Check that comments made by users inside field data are preserved.
         """
-        block = self.parse_xml_to_block("""\
+        block = self.parse_xml_to_block(u"""\
                     <!-- This is a comment outside a block - it can be lost -->
                     <customxml>A<!--B--><leaf/>C<leaf/><!--D-->E</customxml>
                     """)
@@ -191,17 +190,17 @@ class ParsingTest(XmlTest, unittest.TestCase):
         self.assertEqual(len(block.children), 2)
 
         xml = self.export_xml_for_block(block)
-        self.assertIn('A<!--B--><leaf/>C<leaf/><!--D-->E', xml)
+        self.assertIn(b'A<!--B--><leaf/>C<leaf/><!--D-->E', xml)
         block_imported = self.parse_xml_to_block(xml)
         self.assertEqual(
             block_imported.inner_xml,
-            "A<!--B--><leaf/>C<leaf/><!--D-->E"
+            u'A<!--B--><leaf/>C<leaf/><!--D-->E',
         )
 
     @XBlock.register_temp_plugin(Leaf)
     @XBlock.register_temp_plugin(Specialized)
     def test_customized_parsing(self):
-        block = self.parse_xml_to_block("""\
+        block = self.parse_xml_to_block(u"""\
                     <specialized>
                         <leaf/><leaf/><leaf/>
                     </specialized>
@@ -222,17 +221,26 @@ class ExportTest(XmlTest, unittest.TestCase):
 
     @XBlock.register_temp_plugin(Leaf)
     def test_dead_simple_export(self):
-        block = self.parse_xml_to_block("<leaf/>")
+        block = self.parse_xml_to_block(u"<leaf/>")
         xml = self.export_xml_for_block(block)
-        self.assertRegexpMatches(
-            xml.strip(),
-            r"\<\?xml version='1.0' encoding='UTF8'\?\>\n\<leaf .*/\>"
+        self.assertIn(
+            b"<?xml version='1.0' encoding='UTF-8'?>\n<leaf ",
+            xml,
+        )
+
+    @XBlock.register_temp_plugin(Leaf)
+    def test_dead_simple_export_binary(self):
+        block = self.parse_xml_to_block(b"<leaf/>")
+        xml = self.export_xml_for_block(block)
+        self.assertIn(
+            b"<?xml version='1.0' encoding='UTF-8'?>\n<leaf ",
+            xml,
         )
 
     @XBlock.register_temp_plugin(Leaf)
     @XBlock.register_temp_plugin(Container)
     def test_export_then_import(self):
-        block = self.parse_xml_to_block(textwrap.dedent("""\
+        block_body = textwrap.dedent(u"""\
             <?xml version='1.0' encoding='utf-8'?>
             <container>
                 <leaf data1='child1' data2='I&#39;m also child1' />
@@ -244,17 +252,19 @@ class ExportTest(XmlTest, unittest.TestCase):
                 </container>
                 <leaf>Some text content.</leaf>
             </container>
-            """))
+            """)
+        block = self.parse_xml_to_block(block_body.encode('utf-8'))
         xml = self.export_xml_for_block(block)
         block_imported = self.parse_xml_to_block(xml)
 
         # Crude checks that the XML is correct.  The exact form of the XML
         # isn't important.
-        self.assertEqual(xml.count("container"), 4)
-        self.assertEqual(xml.count("child1"), 2)
-        self.assertEqual(xml.count("child2"), 1)
-        self.assertEqual(xml.count("ʇxǝʇ uʍop-ǝpısdn"), 1)
-        self.assertEqual(xml.count("ᵾnɨȼøđɇ ȼȺn ƀɇ ŧɍɨȼꝁɏ!"), 1)
+        xml = xml.decode('utf-8')
+        self.assertEqual(xml.count(u"container"), 4)
+        self.assertEqual(xml.count(u"child1"), 2)
+        self.assertEqual(xml.count(u"child2"), 1)
+        self.assertEqual(xml.count(u"ʇxǝʇ uʍop-ǝpısdn"), 1)
+        self.assertEqual(xml.count(u"ᵾnɨȼøđɇ ȼȺn ƀɇ ŧɍɨȼꝁɏ!"), 1)
 
         # The important part: exporting then importing a block should give
         # you an equivalent block.
@@ -262,19 +272,19 @@ class ExportTest(XmlTest, unittest.TestCase):
 
     @XBlock.register_temp_plugin(LeafWithDictAndList)
     def test_dict_and_list_as_attribute(self):
-        block = self.parse_xml_to_block(textwrap.dedent("""\
+        block = self.parse_xml_to_block(textwrap.dedent(u"""\
             <?xml version='1.0' encoding='utf-8'?>
             <leafwithdictandlist
                 dictionary='{"foo": "bar"}'
                 sequence='["one", "two", "three"]' />
-            """))
+            """).encode('utf-8'))
 
-        self.assertEqual(block.dictionary, {"foo": "bar"})
-        self.assertEqual(block.sequence, ["one", "two", "three"])
+        self.assertEqual(block.dictionary, {u"foo": u"bar"})
+        self.assertEqual(block.sequence, [u"one", u"two", u"three"])
 
     @XBlock.register_temp_plugin(LeafWithOption)
     def test_export_then_import_with_options(self):
-        block = self.parse_xml_to_block(textwrap.dedent("""\
+        block = self.parse_xml_to_block(textwrap.dedent(u"""\
             <?xml version='1.0' encoding='utf-8'?>
             <leafwithoption xmlns:option="http://code.edx.org/xblock/option"
                 data1="child1" data2='with a dict'>
@@ -288,7 +298,7 @@ class ExportTest(XmlTest, unittest.TestCase):
                     - some string
                 </option:data4>
             </leafwithoption>
-            """))
+            """).encode('utf-8'))
         xml = self.export_xml_for_block(block)
 
         block_imported = self.parse_xml_to_block(xml)
@@ -296,13 +306,13 @@ class ExportTest(XmlTest, unittest.TestCase):
         self.assertEqual(block_imported.data3, {"child": 1, "with custom option": True})
         self.assertEqual(block_imported.data4, [1.23, True, "some string"])
 
-        self.assertEqual(xml.count("child1"), 1)
+        self.assertEqual(xml.count(b"child1"), 1)
         self.assertTrue(blocks_are_equivalent(block, block_imported))
 
     @XBlock.register_temp_plugin(LeafWithOption)
     def test_dict_and_list_export_format(self):
-        xml = textwrap.dedent("""\
-            <?xml version='1.0' encoding='UTF8'?>
+        xml = textwrap.dedent(u"""\
+            <?xml version='1.0' encoding='UTF-8'?>
             <leafwithoption %s xblock-family="xblock.v1">
               <option:data4>[
               1.23,
@@ -315,10 +325,17 @@ class ExportTest(XmlTest, unittest.TestCase):
             }</option:data3>
             </leafwithoption>
             """) % get_namespace_attrs()
-        block = self.parse_xml_to_block(xml)
+        block = self.parse_xml_to_block(xml.encode('utf-8'))
         exported_xml = self.export_xml_for_block(block)
 
-        self.assertEqual(xml, exported_xml)
+        self.assertIn(
+            u'<option:data4>[\n  1.23,\n  true,\n  "some string"\n]</option:data4>\n',
+            exported_xml.decode('utf-8')
+        )
+        self.assertIn(
+            u'<option:data3>{\n  "child": 1,\n  "with custom option": true\n}</option:data3>\n',
+            exported_xml.decode('utf-8')
+        )
 
     @XBlock.register_temp_plugin(Leaf)
     @ddt.data(
@@ -364,19 +381,28 @@ class TestRoundTrip(XmlTest, unittest.TestCase):
 
     @XBlock.register_temp_plugin(LeafWithDictAndList)
     def test_string_roundtrip(self):
-        """ Test correctly serializes-deserializes List and Dicts with plain string contents """
+        """
+        Test correctly serializes-deserializes List and Dicts with byte string
+        contents in Python 2.
+
+        In Python 3, this behavior is unsupported.  dict and list elements
+        cannot be bytes objects.
+        """
         block = self.create_block("leafwithdictandlist")
 
-        expected_seq = ['1', '2']
-        expected_dict = {'1': '1', 'ping': 'ack'}
+        expected_seq = [b'1', b'2']
+        expected_dict = {b'1': b'1', b'ping': b'ack'}
         block.sequence = expected_seq
         block.dictionary = expected_dict
-        xml = self.export_xml_for_block(block)
 
-        parsed = self.parse_xml_to_block(xml)
+        if future.utils.PY3:
+            self.assertRaises(TypeError, self.export_xml_for_block, block)
+        else:
+            xml = self.export_xml_for_block(block)
+            parsed = self.parse_xml_to_block(xml)
 
-        self.assertEqual(parsed.sequence, expected_seq)
-        self.assertEqual(parsed.dictionary, expected_dict)
+            self.assertEqual(parsed.sequence, expected_seq)
+            self.assertEqual(parsed.dictionary, expected_dict)
 
     @XBlock.register_temp_plugin(LeafWithDictAndList)
     def test_unicode_roundtrip(self):
@@ -408,7 +434,7 @@ class TestRoundTrip(XmlTest, unittest.TestCase):
 
         self.assertEqual(parsed.sequence, expected_seq)
         self.assertNotEqual(parsed.dictionary, expected_dict)
-        self.assertEqual(parsed.dictionary, {str(key): value for key, value in list(expected_dict.items())})
+        self.assertEqual(parsed.dictionary, {str(key): value for key, value in future.utils.iteritems(expected_dict)})
 
     @XBlock.register_temp_plugin(LeafWithDictAndList)
     def test_none_contents_roundtrip(self):

--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -79,7 +79,7 @@ def _num_plugins_cached():
     """
     Returns the number of plugins that have been cached.
     """
-    return len(list(plugin.PLUGIN_CACHE.keys()))
+    return len(plugin.PLUGIN_CACHE)
 
 
 @XBlock.register_temp_plugin(AmbiguousBlock1, "thumbs")

--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -1,6 +1,7 @@
 """
 Test xblock/core/plugin.py
 """
+from __future__ import unicode_literals
 
 from mock import patch, Mock
 

--- a/xblock/test/test_plugin.py
+++ b/xblock/test/test_plugin.py
@@ -79,7 +79,7 @@ def _num_plugins_cached():
     """
     Returns the number of plugins that have been cached.
     """
-    return len(plugin.PLUGIN_CACHE.keys())
+    return len(list(plugin.PLUGIN_CACHE.keys()))
 
 
 @XBlock.register_temp_plugin(AmbiguousBlock1, "thumbs")

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -2,7 +2,7 @@
 """Tests the features of xblock/runtime"""
 from __future__ import print_function
 from __future__ import unicode_literals
-from builtins import object, str
+from builtins import object, str  # pylint: disable=redefined-builtin
 import future.utils
 # Allow tests to access private members of classes
 # pylint: disable=W0212

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -692,7 +692,7 @@ class TestRuntimeDeprecation(WarningTestMixin, TestCase):
         with self.assertWarns(FieldDataDeprecationWarning):
             runtime = TestRuntime(Mock(spec=IdReader), field_data)
         with self.assertWarns(FieldDataDeprecationWarning):
-            self.assertEquals(runtime.field_data, field_data)
+            self.assertEqual(runtime.field_data, field_data)
 
     def test_set_field_data(self):
         field_data = Mock(spec=FieldData)
@@ -700,4 +700,4 @@ class TestRuntimeDeprecation(WarningTestMixin, TestCase):
         with self.assertWarns(FieldDataDeprecationWarning):
             runtime.field_data = field_data
         with self.assertWarns(FieldDataDeprecationWarning):
-            self.assertEquals(runtime.field_data, field_data)
+            self.assertEqual(runtime.field_data, field_data)

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests the features of xblock/runtime"""
+from __future__ import print_function
 # Allow tests to access private members of classes
 # pylint: disable=W0212
 
@@ -121,16 +122,16 @@ def check_field(collection, field):
     Sets the field to a new value and asserts that the update properly occurs.
     Deletes the new value, and asserts that the default value is properly restored.
     """
-    print "Getting %s from %r" % (field.name, collection)
+    print("Getting %s from %r" % (field.name, collection))
     assert_equals(field.default, getattr(collection, field.name))
     new_value = 'new ' + field.name
-    print "Setting %s to %s on %r" % (field.name, new_value, collection)
+    print("Setting %s to %s on %r" % (field.name, new_value, collection))
     setattr(collection, field.name, new_value)
-    print "Checking %s on %r" % (field.name, collection)
+    print("Checking %s on %r" % (field.name, collection))
     assert_equals(new_value, getattr(collection, field.name))
-    print "Deleting %s from %r" % (field.name, collection)
+    print("Deleting %s from %r" % (field.name, collection))
     delattr(collection, field.name)
-    print "Back to defaults for %s in %r" % (field.name, collection)
+    print("Back to defaults for %s in %r" % (field.name, collection))
     assert_equals(field.default, getattr(collection, field.name))
 
 
@@ -225,7 +226,7 @@ def test_querypath_parsing():
     mrun = MockRuntimeForQuerying()
     block = Mock()
     mrun.querypath(block, "..//@hello")
-    print mrun.mock_query.mock_calls
+    print(mrun.mock_query.mock_calls)
     expected = Mock()
     expected.parent().descendants().attr("hello")
     assert mrun.mock_query.mock_calls == expected.mock_calls

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -3,15 +3,15 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import object, str  # pylint: disable=redefined-builtin
-import future.utils
 # Allow tests to access private members of classes
 # pylint: disable=W0212
 
 from collections import namedtuple
 from datetime import datetime
-from mock import Mock, patch
 from unittest import TestCase
 
+import future.utils
+from mock import Mock, patch
 from xblock.core import XBlock, XBlockMixin
 from xblock.fields import BlockScope, Scope, String, ScopeIds, List, UserScope, Integer
 from xblock.exceptions import (

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests the features of xblock/runtime"""
 from __future__ import print_function
-from builtins import object
+from builtins import object, str
+import future.utils
 # Allow tests to access private members of classes
 # pylint: disable=W0212
 
@@ -146,7 +147,7 @@ def test_db_model_keys():
 
     assert_false(field_data.has(tester, 'not a field'))
 
-    for field in list(tester.fields.values()):
+    for field in future.utils.itervalues(tester.fields):
         new_value = 'new ' + field.name
         assert_false(field_data.has(tester, field.name))
         if isinstance(field, List):
@@ -157,7 +158,7 @@ def test_db_model_keys():
     tester.save()
 
     # Make sure everything saved correctly
-    for field in list(tester.fields.values()):
+    for field in future.utils.itervalues(tester.fields):
         assert_true(field_data.has(tester, field.name))
 
     def get_key_value(scope, user_id, block_scope_id, field_name):
@@ -410,7 +411,7 @@ class Dynamic(object):
     Object for testing that sets attrs based on __init__ kwargs
     """
     def __init__(self, **kwargs):
-        for name, value in list(kwargs.items()):
+        for name, value in future.utils.iteritems(kwargs):
             setattr(self, name, value)
 
 

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests the features of xblock/runtime"""
 from __future__ import print_function
+from __future__ import unicode_literals
 from builtins import object, str
 import future.utils
 # Allow tests to access private members of classes

--- a/xblock/test/test_runtime.py
+++ b/xblock/test/test_runtime.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests the features of xblock/runtime"""
 from __future__ import print_function
+from builtins import object
 # Allow tests to access private members of classes
 # pylint: disable=W0212
 
@@ -145,7 +146,7 @@ def test_db_model_keys():
 
     assert_false(field_data.has(tester, 'not a field'))
 
-    for field in tester.fields.values():
+    for field in list(tester.fields.values()):
         new_value = 'new ' + field.name
         assert_false(field_data.has(tester, field.name))
         if isinstance(field, List):
@@ -156,7 +157,7 @@ def test_db_model_keys():
     tester.save()
 
     # Make sure everything saved correctly
-    for field in tester.fields.values():
+    for field in list(tester.fields.values()):
         assert_true(field_data.has(tester, field.name))
 
     def get_key_value(scope, user_id, block_scope_id, field_name):
@@ -409,7 +410,7 @@ class Dynamic(object):
     Object for testing that sets attrs based on __init__ kwargs
     """
     def __init__(self, **kwargs):
-        for name, value in kwargs.items():
+        for name, value in list(kwargs.items()):
             setattr(self, name, value)
 
 
@@ -537,8 +538,8 @@ class XBlockWithServices(XBlock):
         def assert_equals_unicode(str1, str2):
             """`str1` equals `str2`, and both are Unicode strings."""
             assert_equals(str1, str2)
-            assert isinstance(str1, unicode)
-            assert isinstance(str2, unicode)
+            assert isinstance(str1, str)
+            assert isinstance(str2, str)
 
         i18n = self.runtime.service(self, "i18n")
         assert_equals_unicode(u"Welcome!", i18n.ugettext("Welcome!"))
@@ -589,7 +590,7 @@ def test_ugettext_calls():
     runtime = TestRuntime()
     block = XBlockWithServices(runtime, scope_ids=Mock(spec=[]))
     assert_equals(block.ugettext('test'), u'test')
-    assert_true(isinstance(block.ugettext('test'), unicode))
+    assert_true(isinstance(block.ugettext('test'), str))
 
     # NoSuchServiceError exception should raise if i18n is none/empty.
     runtime = TestRuntime(services={

--- a/xblock/test/test_test_tools.py
+++ b/xblock/test/test_test_tools.py
@@ -3,6 +3,7 @@
 "The only code you have to test is the code you want to work."
 
 """
+from __future__ import unicode_literals
 from builtins import object
 
 from abc import ABCMeta, abstractmethod

--- a/xblock/test/test_test_tools.py
+++ b/xblock/test/test_test_tools.py
@@ -4,17 +4,16 @@
 
 """
 from __future__ import unicode_literals
-from builtins import object
+from builtins import object  # pylint: disable=redefined-builtin
 
 from abc import ABCMeta, abstractmethod
-
-import unittest
+from unittest import TestCase
 
 from xblock.test.tools import unabc
-from future.utils import with_metaclass
+import future.utils
 
 
-class Abstract(with_metaclass(ABCMeta, object)):
+class Abstract(future.utils.with_metaclass(ABCMeta, object)):
     """Our test subject: an abstract class with two abstract methods."""
 
     def concrete(self, arg):
@@ -44,7 +43,7 @@ class ForceConcreteMessage(Abstract):
     pass
 
 
-class TestUnAbc(unittest.TestCase):
+class TestUnAbc(TestCase):
     """Test the @unabc decorator."""
 
     def test_cant_abstract(self):

--- a/xblock/test/test_test_tools.py
+++ b/xblock/test/test_test_tools.py
@@ -3,18 +3,18 @@
 "The only code you have to test is the code you want to work."
 
 """
+from builtins import object
 
 from abc import ABCMeta, abstractmethod
 
 import unittest
 
 from xblock.test.tools import unabc
+from future.utils import with_metaclass
 
 
-class Abstract(object):
+class Abstract(with_metaclass(ABCMeta, object)):
     """Our test subject: an abstract class with two abstract methods."""
-
-    __metaclass__ = ABCMeta
 
     def concrete(self, arg):
         """This is available as-is on all subclasses."""

--- a/xblock/test/test_user_service.py
+++ b/xblock/test/test_user_service.py
@@ -2,8 +2,9 @@
 Tests for the UserService
 """
 from __future__ import unicode_literals
-from past.builtins import basestring  # pylint: disable=redefined-builtin
 import collections
+
+from past.builtins import basestring  # pylint: disable=redefined-builtin
 from xblock.reference.user_service import XBlockUser, UserService
 from xblock.test.tools import assert_equals, assert_raises, assert_is_instance, assert_false
 

--- a/xblock/test/test_user_service.py
+++ b/xblock/test/test_user_service.py
@@ -1,6 +1,7 @@
 """
 Tests for the UserService
 """
+from past.builtins import basestring
 import collections
 from xblock.reference.user_service import XBlockUser, UserService
 from xblock.test.tools import assert_equals, assert_raises, assert_is_instance, assert_false

--- a/xblock/test/test_user_service.py
+++ b/xblock/test/test_user_service.py
@@ -2,7 +2,7 @@
 Tests for the UserService
 """
 from __future__ import unicode_literals
-from past.builtins import basestring
+from past.builtins import basestring  # pylint: disable=redefined-builtin
 import collections
 from xblock.reference.user_service import XBlockUser, UserService
 from xblock.test.tools import assert_equals, assert_raises, assert_is_instance, assert_false

--- a/xblock/test/test_user_service.py
+++ b/xblock/test/test_user_service.py
@@ -1,6 +1,7 @@
 """
 Tests for the UserService
 """
+from __future__ import unicode_literals
 from past.builtins import basestring
 import collections
 from xblock.reference.user_service import XBlockUser, UserService

--- a/xblock/test/test_validation.py
+++ b/xblock/test/test_validation.py
@@ -1,6 +1,7 @@
 """
 Test xblock/validation.py
 """
+from __future__ import unicode_literals
 
 import unittest
 from xblock.test.tools import assert_raises

--- a/xblock/test/test_validation.py
+++ b/xblock/test/test_validation.py
@@ -21,7 +21,7 @@ class ValidationMessageTest(unittest.TestCase):
             ValidationMessage("unknown type", u"Unknown type info")
 
         with assert_raises(TypeError):
-            ValidationMessage(ValidationMessage.WARNING, "Non-unicode message")
+            ValidationMessage(ValidationMessage.WARNING, b"Non-unicode message")
 
     def test_to_json(self):
         """

--- a/xblock/test/tools.py
+++ b/xblock/test/tools.py
@@ -2,8 +2,7 @@
 Tools for testing XBlocks
 """
 from __future__ import unicode_literals
-from builtins import zip
-from builtins import object
+from builtins import object, zip  # pylint: disable=redefined-builtin
 import warnings
 
 from contextlib import contextmanager

--- a/xblock/test/tools.py
+++ b/xblock/test/tools.py
@@ -1,6 +1,7 @@
 """
 Tools for testing XBlocks
 """
+from __future__ import unicode_literals
 from builtins import zip
 from builtins import object
 import warnings

--- a/xblock/test/tools.py
+++ b/xblock/test/tools.py
@@ -1,6 +1,8 @@
 """
 Tools for testing XBlocks
 """
+from builtins import zip
+from builtins import object
 import warnings
 
 from contextlib import contextmanager

--- a/xblock/test/toy_runtime.py
+++ b/xblock/test/toy_runtime.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     import json
 
+import future.utils
 from xblock.fields import Scope
 from xblock.runtime import (
     KvsFieldData, KeyValueStore, Runtime, MemoryIdManager
@@ -84,7 +85,7 @@ class ToyRuntimeKeyValueStore(KeyValueStore):
         `update_dict`: A dictionary of keys: values.
         This method sets the value of each key to the specified new value.
         """
-        for key, value in list(update_dict.items()):
+        for key, value in future.utils.iteritems(update_dict):
             # We just call `set` directly here, because this is an in-memory representation
             # thus we don't concern ourselves with bulk writes.
             self.set(key, value)

--- a/xblock/test/toy_runtime.py
+++ b/xblock/test/toy_runtime.py
@@ -83,7 +83,7 @@ class ToyRuntimeKeyValueStore(KeyValueStore):
         `update_dict`: A dictionary of keys: values.
         This method sets the value of each key to the specified new value.
         """
-        for key, value in update_dict.items():
+        for key, value in list(update_dict.items()):
             # We just call `set` directly here, because this is an in-memory representation
             # thus we don't concern ourselves with bulk writes.
             self.set(key, value)

--- a/xblock/test/toy_runtime.py
+++ b/xblock/test/toy_runtime.py
@@ -1,4 +1,5 @@
 """A very basic toy runtime for XBlock tests."""
+from __future__ import unicode_literals
 import logging
 
 try:

--- a/xblock/validation.py
+++ b/xblock/validation.py
@@ -1,6 +1,8 @@
 """
 Validation information for an xblock instance.
 """
+from builtins import str
+from builtins import object
 
 
 class ValidationMessage(object):
@@ -23,7 +25,7 @@ class ValidationMessage(object):
         """
         if message_type not in self.TYPES:
             raise TypeError("Unknown message_type: " + message_type)
-        if not isinstance(message_text, unicode):
+        if not isinstance(message_text, str):
             raise TypeError("Message text must be unicode")
         self.type = message_type
         self.text = message_text
@@ -112,7 +114,7 @@ class Validation(object):
             dict: A dict representation that is json-serializable.
         """
         return {
-            "xblock_id": unicode(self.xblock_id),
+            "xblock_id": str(self.xblock_id),
             "messages": [message.to_json() for message in self.messages],
             "empty": self.empty
         }

--- a/xblock/validation.py
+++ b/xblock/validation.py
@@ -1,6 +1,7 @@
 """
 Validation information for an xblock instance.
 """
+from __future__ import unicode_literals
 from builtins import str
 from builtins import object
 

--- a/xblock/validation.py
+++ b/xblock/validation.py
@@ -2,8 +2,7 @@
 Validation information for an xblock instance.
 """
 from __future__ import unicode_literals
-from builtins import str
-from builtins import object
+from builtins import str, object  # pylint: disable=redefined-builtin
 
 
 class ValidationMessage(object):


### PR DESCRIPTION
@nedbat, @jcdyer, @maxrothman: This converts XBlock to python3 using `future` and `futurize`. It also converts the tests to use tox, because I found maintaining my own virtualenvs to be tedious, and I had a branch that set up tox lying around from 2015.
