### PR TITLE
Update readme for python3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,6 @@ This code runs and is tested on Python 2.7 and 3.5.
 
         $ pip install -r requirements.txt
 
-.. _a fork of XBlock that provides Python 3 support: https://github.com/singingwolfboy/XBlock/tree/py3
-
 
 Testing
 --------

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,7 @@ to give us a virtual machine image which ran it.
 Installation
 ------------
 
-This code runs on Python 2.7. If you prefer to use Python 3, there is `a fork
-of XBlock that provides Python 3 support`_, but this fork is not yet supported
-by edX.
+This code runs and is tested on Python 2.7 and 3.5.
 
 1.  Get a local copy of this repo.
 


### PR DESCRIPTION
It looks like python 3 compatibility was added four months ago: https://github.com/edx/XBlock/commit/4700c7cb5b05fbfbea7d125525b681f9bccc23c3

And XBlock is now being tested by travis in 2.7 and 3.5.