### PR TITLE
Fix Travis deploy to PyPI for new tags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 sudo: false
-branches:
-  only:
-    - master
 python:
   - 2.7
   - 3.5
@@ -31,3 +28,4 @@ deploy:
   on:
     tags: true
     python: 3.5
+    condition: '$TOX_ENV = django111'


### PR DESCRIPTION
As @clintonb recommended, removing `branches => only -> master` to get it to build on tags.

Also, the condition will run this on just one of the sub-builds in Travis.

See the Travis build for the test tag I created:
https://travis-ci.org/edx/XBlock/builds/303211533

FYI: @feanil @fredsmith @clintonb