### PR TITLE
PLAT-1413 Remove obsolete TEMPLATE_* settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
   include:
     - python: 3.5
       env: TOX_ENV=docs
+    - python: 3.5
+      env: TOX_ENV=quality
 script:
   - tox -e $TOX_ENV
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 quality:
-	pep8
+	pycodestyle
 	script/max_pylint_violations
 	pylint --py3k xblock
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ coverage
 astroid
 pylint
 rednose
-pep8
+pycodestyle
 caniusepython3
 diff-cover >= 0.2.1
 ddt==0.8.0

--- a/script/max_pylint_violations
+++ b/script/max_pylint_violations
@@ -1,5 +1,5 @@
 #!/bin/bash
-DEFAULT_MAX=6
+DEFAULT_MAX=7
 
 pylint xblock | tee /tmp/pylint-xblock.log
 ERR=`grep -E "^[C|R|W|E]:" /tmp/pylint-xblock.log | wc -l`

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,12 @@ rednose=1
 # Uncomment the following line to open pdb when a test fails
 #pdb=1
 
-[pep8]
-ignore=E501,E402
+[pycodestyle]
+# error codes: https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+# E402: module level import not at top of file
+#   We catch this with pylint, don't need 2 reports of the same issue
+# E501: line too long
+# E722: do not use bare except, specify exception instead
+#   We catch this with pylint, don't need 2 reports of the same issue
+ignore=E501,E402,E722
 exclude=doc/*,.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ deps =
     -rrequirements.txt
 commands =
     coverage run -m nose {posargs}
-    py27-django18: make quality
 whitelist_externals =
      make
 
@@ -31,3 +30,10 @@ deps=
     -rdoc/requirements.txt
 commands =
     make html
+
+[testenv:quality]
+deps =
+    Django>=1.11,<2.0
+    -rrequirements.txt
+commands =
+    make quality

--- a/xblock/completable.py
+++ b/xblock/completable.py
@@ -3,6 +3,7 @@ This module defines CompletableXBlockMixin and completion mode enumeration.
 """
 from __future__ import absolute_import, unicode_literals
 
+
 class XBlockCompletionMode(object):
     """
     Enumeration for completion modes.

--- a/xblock/test/settings.py
+++ b/xblock/test/settings.py
@@ -5,10 +5,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
-
-# The variable doesn't seem to actually get interpolated in
-TEMPLATE_STRING_IF_INVALID = "<MISSING VARIABLE '%s'>"
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
@@ -89,13 +85,6 @@ STATICFILES_FINDERS = (
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '5ftdd9(@p)tg&amp;bqv$(^d!63psz9+g+_i5om_e%!32%po2_+%l7'
-
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    # 'django.template.loaders.eggs.Loader',
-)
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',

--- a/xblock/test/test_fields_api.py
+++ b/xblock/test/test_fields_api.py
@@ -548,6 +548,7 @@ class SaveNoopPrefix(object):
         self.block.save()
 # pylint: enable=no-member
 
+
 for operation_backend in (BlockFirstOperations, FieldFirstOperations):
     for noop_prefix in (None, GetNoopPrefix, GetSaveNoopPrefix, SaveNoopPrefix):
         for base_test_case in (


### PR DESCRIPTION
Removed obsolete (and unused) TEMPLATE_* settings.  I also noticed that we haven't been running quality checks in Travis for a while due to a tox environment name mismatch; I broke those out into a separate tox environment and fixed the minor new issues it reported.  The violation threshold did increase by one, due to a new `FIXME` comment in `xblock/test/test_core.py` which will take some investigation (and possibly a switch to pytest) to resolve.