### PR TITLE
 Don't translate lazily-translated default string value.

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,21 @@
+import os
+import sys
+os.environ['DJANGO_SETTINGS_MODULE'] = 'xblock.test.settings'
+
+from django.conf import settings
+settings.configure(
+    DEBUG=True,
+    ALLOWED_HOSTS='*'
+)
+
+import django
+django.setup()
+
+# Now we instantiate a test runner...
+from django.test.utils import get_runner
+TestRunner = get_runner(settings)
+
+# And then we run tests and return the results.
+test_runner = TestRunner(verbosity=2, interactive=True)
+failures = test_runner.run_tests(['xblock.test.django.test_field_translation'])
+sys.exit(failures)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35}-django{18,110,111}
+envlist = py{27,36}-django{18,110,111}
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -12,9 +12,10 @@ deps =
     django18: Django>=1.8,<1.9
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
-    -r requirements/test.txt
+    -rrequirements/test.txt
 commands =
     coverage run -m nose {posargs}
+    coverage run -m runner.py
 whitelist_externals =
      make
 

--- a/xblock/test/django/test_field_translation.py
+++ b/xblock/test/django/test_field_translation.py
@@ -1,0 +1,62 @@
+"""
+Test the case when a lazily-translated string is given as a default for
+an XBlock String field.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+# Set up Django settings
+import os
+from mock import Mock
+from unittest import TestCase
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "xblock.test.settings")
+
+# pylint: disable=wrong-import-position
+try:
+    from django.utils.translation import ugettext_lazy as _  # pylint: disable=import-error
+    HAS_DJANGO = True
+except ImportError:
+    HAS_DJANGO = False
+
+# Django isn't always available, so skip tests if it isn't.
+from nose.plugins.skip import SkipTest
+
+from xblock import fields  # pylint: disable=unused-import
+# pylint: enable=wrong-import-position
+
+from xblock.core import XBlock, XBlockMixin
+from xblock.fields import BlockScope, Scope, String, ScopeIds, List, UserScope, Integer
+from xblock.runtime import (
+    DictKeyValueStore,
+    KvsFieldData,
+)
+from xblock.test.tools import assert_equals, TestRuntime
+
+
+class TestXBlock(XBlock):
+    """
+    Set up a class that contains a single string field with a translated default.
+    """
+    STR_DEFAULT_ENG = 'ENG: String to be translated'
+    str_field = String(scope=Scope.settings, default=_(STR_DEFAULT_ENG))
+
+class TestXBlockStringFieldDefaultTranslation(TestCase):
+
+    def setUp(self):
+        from django.conf import settings
+        try:
+            if settings.is_defined('DEBUG'):
+                pass
+        except:
+            raise SkipTest("Not running in Django context.")
+
+    def test_db_model_keys(self):
+        # Construct a runtime and an XBlock using it.
+        key_store = DictKeyValueStore()
+        field_data = KvsFieldData(key_store)
+        runtime = TestRuntime(Mock(), services={'field-data': field_data})
+        tester = runtime.construct_xblock_from_class(TestXBlock, ScopeIds('s0', 'TestXBlock', 'd0', 'u0'))
+        # Check instantiated XBlock str_field value - ensure not translated.
+        assert_equals(tester.str_field, tester.STR_DEFAULT_ENG)
+        # Save XBlock - verify str_field *is* translated.


### PR DESCRIPTION
Not happy with this impl yet. 
I'm looking for your input into how to properly allow lazily translated default values for XBlock String fields.