### PR TITLE
Fix codecov data reporting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,10 @@ deps =
 changedir = {envsitepackagesdir}
 commands =
     pytest {posargs:xblock}
+    mv .coverage {toxinidir}/.coverage
 whitelist_externals =
     make
+    mv
 
 [testenv:docs]
 basepython =


### PR DESCRIPTION
The workaround for pytest finding tests both in the root directory and the installed packages left the collected coverage data file in the wrong place.  Move it where expected and see if this fixes codecov reports.