### PR TITLE
Add support for DRF Request to DjangoWebobRequest.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,6 +25,7 @@ diff-cover==1.0.2
 distlib==0.2.7
 django-pyfs==2.0
 django==1.11.13
+-e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 docutils==0.14
 enum34==1.1.6
 first==2.0.1

--- a/requirements/django.in
+++ b/requirements/django.in
@@ -5,4 +5,5 @@
 
 Django>=1.8,<2.0
 django-pyfs>=1.0.5
+-e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 lazy

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -10,6 +10,7 @@ boto3==1.7.44             # via fs-s3fs
 botocore==1.10.44         # via boto3, s3transfer
 django-pyfs==2.0
 django==1.11.13
+-e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 docutils==0.14            # via botocore
 enum34==1.1.6
 fs-s3fs==0.1.8            # via django-pyfs

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,6 +14,7 @@ certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 django-pyfs==2.0
 django==1.11.13
+-e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 docutils==0.14
 edx-sphinx-theme==1.3.0
 enum34==1.1.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,6 +22,7 @@ ddt==0.8.0
 diff-cover==1.0.2
 distlib==0.2.7            # via caniusepython3
 django-pyfs==2.0
+-e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 docutils==0.14
 enum34==1.1.6
 fs-s3fs==0.1.8

--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -61,7 +61,7 @@ class HandlersMixin(object):
             if request.method != "POST":
                 return JsonHandlerError(405, "Method must be POST").get_response(allow=["POST"])
             try:
-                request_json = json.loads(request.body)
+                request_json = request.json_data
             except ValueError:
                 return JsonHandlerError(400, "Invalid JSON").get_response()
             try:

--- a/xblock/test/test_core.py
+++ b/xblock/test/test_core.py
@@ -15,7 +15,7 @@ import unittest
 
 import ddt
 import six
-from mock import patch, MagicMock, Mock
+from mock import patch, MagicMock, Mock, PropertyMock
 import pytest
 from webob import Response
 
@@ -827,7 +827,8 @@ def test_json_handler_basic():
     test_data = {"foo": "bar", "baz": "quux"}
     test_data_json = ['{"foo": "bar", "baz": "quux"}', '{"baz": "quux", "foo": "bar"}']
     test_suffix = "suff"
-    test_request = Mock(method="POST", body=test_data_json[0])
+    test_request = Mock(method="POST")
+    type(test_request).json_data = PropertyMock(return_value=test_data)
 
     @XBlock.json_handler
     def test_func(self, request, suffix):
@@ -844,6 +845,7 @@ def test_json_handler_basic():
 
 def test_json_handler_invalid_json():
     test_request = Mock(method="POST", body="{")
+    type(test_request).json_data = PropertyMock(side_effect=ValueError())
 
     @XBlock.json_handler
     def test_func(self, request, suffix):   # pylint: disable=unused-argument
@@ -872,6 +874,7 @@ def test_json_handler_get():
 
 def test_json_handler_empty_request():
     test_request = Mock(method="POST", body="")
+    type(test_request).json_data = PropertyMock(side_effect=ValueError())
 
     @XBlock.json_handler
     def test_func(self, request, suffix):   # pylint: disable=unused-argument
@@ -913,7 +916,7 @@ def test_json_handler_return_response():
 
 
 def test_json_handler_return_unicode():
-    test_request = Mock(method="POST", body='["foo", "bar"]')
+    test_request = Mock(method="POST", json_data='["foo", "bar"]')
 
     @XBlock.json_handler
     def test_func(self, request, suffix):  # pylint: disable=unused-argument


### PR DESCRIPTION
https://github.com/edx/edx-platform/pull/15940 converted `handle_xblock_callback` into a DRF view. However, that resulted in `django.http.request:RawPostDataException: You cannot access body after reading from request's data stream` errors in production. See https://openedx.atlassian.net/browse/EDUCATOR-3012. Because of which it had to be reverted.

The exception happens if an ajax request is made with `Content-Type:application/json`. and not if with `Content-Type:application/x-www-form-urlencoded`. For example, video player `post_completion` call does the former (the stacktrace in the ticket is for this case) and the vertical `post_completion` call does the later.

Why does this happen:
1. Django and DRF treat these two content-types differently: https://github.com/django/django/blob/1.8.18/django/http/request.py#L229-L275
https://github.com/edx/django-rest-framework/blob/master/rest_framework/request.py#L272-L298
2. Django `request.body` cannot be called after calling `request.read()`.
3. When for `Content-Type:application/json`,  `drf_request.POST` is accessed (which is a wrapper around Django request) it calls `django_request.read()` and caches the results on itself:
```
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/authentication.py", line 137, in enforce_csrf
edx.devstack.lms     |     reason = CSRFCheck().process_view(request, None, (), {})
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/middleware/csrf.py", line 300, in process_view
edx.devstack.lms     |     request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/request.py", line 378, in __getattribute__
edx.devstack.lms     |     return super(Request, self).__getattribute__(attr)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/request.py", line 397, in POST
edx.devstack.lms     |     self._load_data_and_files()
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/request.py", line 246, in _load_data_and_files
edx.devstack.lms     |     self._data, self._files = self._parse()
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/request.py", line 315, in _parse
edx.devstack.lms     |     parsed = parser.parse(stream, media_type, self.parser_context)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/parsers.py", line 64, in parse
edx.devstack.lms     |     data = stream.read().decode(encoding)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/http/request.py", line 330, in read
```
4. Because of this when `XBlock` does a `json.load(request.body)` DRF forwards the call to `django_request.body`, which results in this exception:

```
edx.devstack.lms     |   File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1114, in _get_course_and_invoke_handler
edx.devstack.lms     |     return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
edx.devstack.lms     |   File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1065, in _invoke_xblock_handler
edx.devstack.lms     |     resp = instance.handle(handler, req, suffix)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 89, in handle
edx.devstack.lms     |     return self.runtime.handle(self, handler_name, request, suffix)
edx.devstack.lms     |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1347, in handle
edx.devstack.lms     |     return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 1029, in handle
edx.devstack.lms     |     results = handler(request, suffix)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 64, in wrapper
edx.devstack.lms     |     request_json = json.loads(request.body)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/lazy/lazy.py", line 28, in __get__
edx.devstack.lms     |     value = self.__func(inst)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/django/request.py", line 153, in body
edx.devstack.lms     |     return self._request.body
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/request.py", line 382, in __getattribute__
edx.devstack.lms     |     return getattr(self._request, attr)
edx.devstack.lms     |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/http/request.py", line 262, in body
edx.devstack.lms     |     raise RawPostDataException("You cannot access body after reading from request's data stream")
```
5. It works in the case of `Content-Type:application/x-www-form-urlencoded` because `django_request.body` has already been [called](https://github.com/django/django/blob/1.8.18/django/http/request.py#L273) earlier when the Track Middleware [calls](https://github.com/edx/edx-platform/blob/master/common/djangoapps/track/middleware.py#L65) `request.POST` and when `csrf_middleware` calls `drf_request.POST`, it returns the [data from](https://github.com/edx/django-rest-framework/blob/master/rest_framework/request.py#L297-L298) `django_request.POST` instead of doing a `read()`.

**Possible Solutions**
1. `json_handler` should check if the request object passed to it is a Django `HttpRequest` object or a DRF `Request` object and read the data appropriately. This PR is one way of doing that.
2. Add a global custom parser `JSONParser` to DRF settings which after doing a `django_request.read()` sets the data on `django_request._body` so that when `django_request.body()` is called, this exception is not raised and `_body` is returned. See https://stackoverflow.com/a/47662497 for details.

Option 1 is explicit. Option 2 is transparent as far as the XBlock runtime is concerned but requires messing around with private variables and may result in unexpected behavior if views set their own parsers.