### PR TITLE
Declare OEP-7 compliance

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -6,7 +6,9 @@ oeps:
     oep-2: true
     oep-7: true
     oep-18: true
-owner: edx/platform-team
+owner: cpennington
+supporting_teams:
+    - platform-core
 tags:
-    - xblock
-    - library
+  - xblock
+  - library

--- a/setup.py
+++ b/setup.py
@@ -45,15 +45,13 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ]
 )


### PR DESCRIPTION
We had already updated tox and Travis to test against Python 3.6, but had not yet updated the trove classifiers or openedx.yaml to reflect this.  Doing so now.