### PR TITLE
chore: Remove old path.py dependency, which has been renamed as 'path'.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -52,7 +52,7 @@ coverage==5.5
     #   pytest-cov
 ddt==1.4.2
     # via -r requirements/test.txt
-diff-cover==5.1.2
+diff-cover==5.2.0
     # via -r requirements/test.txt
 distlib==0.3.2
     # via
@@ -95,7 +95,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.8.0
+isort==5.9.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -137,12 +137,8 @@ packaging==20.9
     #   -r requirements/travis.txt
     #   pytest
     #   tox
-path.py==12.5.0
-    # via -r requirements/test.txt
 path==16.0.0
-    # via
-    #   -r requirements/test.txt
-    #   path.py
+    # via -r requirements/test.txt
 pep517==0.10.0
     # via
     #   -r requirements/pip-tools.txt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,7 +10,7 @@ ddt
 diff-cover >= 0.2.1
 hypothesis
 mock
-path.py
+path
 pycodestyle
 pylint
 pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,7 +34,7 @@ coverage==5.5
     #   pytest-cov
 ddt==1.4.2
     # via -r requirements/test.in
-diff-cover==5.1.2
+diff-cover==5.2.0
     # via -r requirements/test.in
 distlib==0.3.2
     # via virtualenv
@@ -63,7 +63,7 @@ inflect==5.3.0
     # via jinja2-pluralize
 iniconfig==1.1.1
     # via pytest
-isort==5.8.0
+isort==5.9.1
     # via pylint
 jinja2-pluralize==0.3.0
     # via diff-cover
@@ -94,10 +94,8 @@ packaging==20.9
     # via
     #   pytest
     #   tox
-path.py==12.5.0
-    # via -r requirements/test.in
 path==16.0.0
-    # via path.py
+    # via -r requirements/test.in
 pluggy==0.13.1
     # via
     #   diff-cover


### PR DESCRIPTION
Upgraded dependencies via `make upgrade` after changing the requirement.