### PR TITLE
Remove Python 2.7 support from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ to give us a virtual machine image which ran it.
 Installation
 ------------
 
-This code runs and is tested on Python 2.7 and 3.5.
+This code runs and is tested on Python 3.8.
 
 1.  Get a local copy of this repo.
 


### PR DESCRIPTION
Simple fix in the README to remove mention of Python2.7, since XBlock no longer supports it, and also update 3.5 to 3.8.