### PR TITLE
build: use v2 of the codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       run: tox -e ${{ matrix.toxenv }}
 
     - name: Run Coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv=='django22'
-      uses: codecov/codecov-action@v1
+      if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
+      uses: codecov/codecov-action@v2
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,8 @@ deps =
 changedir = {envsitepackagesdir}
 commands =
 	python -Wd -m pytest {posargs:xblock}
-	mv .coverage {toxinidir}/.coverage
+	python -m coverage xml
+	mv coverage.xml {toxinidir}
 whitelist_externals =
 	make
 	mv


### PR DESCRIPTION
Version 2 of the codecov uploader needs a coverage.xml file to upload.  This change adds a "coverage xml" step to create the file.